### PR TITLE
Move repo

### DIFF
--- a/vagrant/ansible/roles/client.test.prep/defaults/main.yml
+++ b/vagrant/ansible/roles/client.test.prep/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-test_repo: "https://github.com/gluster/samba-integration.git"
-test_repo_branch: "tests"
+test_repo: "https://github.com/samba-in-kubernetes/sit-test-cases.git"
+test_repo_branch: "main"

--- a/vagrant/ansible/roles/client.test.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/client.test.prep/tasks/main.yml
@@ -3,7 +3,7 @@
   - name: Fetch repo/switch to master branch
     git:
       repo: "{{ test_repo }}"
-      version: "master"
+      version: "{{ test_repo_branch }}"
       dest: /root/samba-integration-tests
 
   - name: Fetching PR


### PR DESCRIPTION
Use the new tests repo sit-test-cases
https://github.com/samba-in-kubernetes/sit-test-cases

Tested manually using the following commands separately from /vagrant directory
```
make client.test
```
to use the main test repo from sit-test-cases and also replicated what is used in the centos-ci CI environment using the script https://github.com/anoopcs9/samba-centosci/blob/main/jobs/scripts/gluster-integration/gluster-integration.sh
```
GIT_REPO_URL="https://github.com/samba-in-kubernetes/sit-test-cases.git"
ghprbPullId=1
TEST_EXTRA_VARS="test_repo=${GIT_REPO_URL} test_repo_pr=${ghprbPullId}"
EXTRA_VARS="${TEST_EXTRA_VARS}" make client.test
```
In both cases, I logged into the client vm and looked at the tests repo which have been checked out at /root/samba-integration-tests