### PR TITLE
Sanity tests

### DIFF
--- a/vagrant/ansible/roles/client.test.prep/defaults/main.yml
+++ b/vagrant/ansible/roles/client.test.prep/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-test_repo: "https://github.com/gluster/samba-integration.git"
-test_repo_branch: "tests"
+test_repo: "https://github.com/samba-in-kubernetes/sit-test-cases.git"
+test_repo_branch: "main"

--- a/vagrant/ansible/roles/client.test.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/client.test.prep/tasks/main.yml
@@ -3,7 +3,7 @@
   - name: Fetch repo/switch to master branch
     git:
       repo: "{{ test_repo }}"
-      version: "master"
+      version: "{{ test_repo_branch }}"
       dest: /root/samba-integration-tests
 
   - name: Fetching PR

--- a/vagrant/ansible/roles/client.test.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/client.test.prep/tasks/main.yml
@@ -5,12 +5,14 @@
       repo: "{{ test_repo }}"
       version: "{{ test_repo_branch }}"
       dest: /root/samba-integration-tests
+      force: true
 
   - name: Fetching PR
     git:
       repo: "{{ test_repo }}"
       refspec: +pull/{{ test_repo_pr }}/head:pr{{ test_repo_pr }}
       dest: /root/samba-integration-tests
+      force: true
 
   - set_fact:
       test_repo_branch: "pr{{ test_repo_pr }}"
@@ -24,6 +26,7 @@
     repo: "{{ test_repo }}"
     version: "{{ test_repo_branch }}"
     dest: /root/samba-integration-tests
+    force: true
 
 - name: Create a symlink for test-info.yml file
   file:

--- a/vagrant/ansible/roles/client.test.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/client.test.prep/tasks/main.yml
@@ -33,3 +33,9 @@
     group: root
     state: link
 
+- name: Check if only sanity tests required
+  copy:
+    content: 'sanity'
+    dest: /root/samba-integration-tests/testcases/tests
+    force: true
+  when: test_sanity_only is defined


### PR DESCRIPTION
Make use of the new sanity test symlink in the sit-test-cases repo 
https://github.com/samba-in-kubernetes/sit-test-cases/pull/2

This is expected to be used by the CI environment in the sit-environment repo as we would like a quick turnaround when testing in the CI environment and we only need to validate the correctness of the sit-environment repo.

This was bought about because changes in the samba and clustered filesystem repo can cause failures in the smbtorture tests for no fault in the sit-environment repository.

To set up sanity testing only, we need to pass the 'test_sanity_only=1' in the EXTRA_VARS in the CI environment. 

depends on #pr1 
depends on samba-in-kubernetes/sit-test-cases#pr2