### PR TITLE
Sanity tests for CI

### DIFF
--- a/vagrant/ansible/roles/client.test/tasks/main.yml
+++ b/vagrant/ansible/roles/client.test/tasks/main.yml
@@ -3,3 +3,10 @@
   command:
     chdir: /root/samba-integration-tests
     cmd: make test
+  when: test_sanity_only is undefined
+
+- name: Run sanity tests
+  command:
+    chdir: /root/samba-integration-tests
+    cmd: make sanity_test
+  when: test_sanity_only is defined


### PR DESCRIPTION
Make use of the new sanity test target in the sit-test-cases repo
https://github.com/samba-in-kubernetes/sit-test-cases/pull/3

This is expected to be used by the CI environment in the sit-environment repo as we would like a quick turnaround when testing in the CI environment and we only need to validate the correctness of the sit-environment repo.

This was bought about because changes in the samba and clustered filesystem repo can cause failures in the smbtorture tests for no fault in the sit-environment repository.

To set up sanity testing only, we need to pass the 'test_sanity_only=1' in the EXTRA_VARS in the CI environment.

depends on #1 samba-in-kubernetes/sit-test-cases#3