### PR TITLE
ctdb.setup: Use 'cluster lock' instead of 'recovery lock'

### DIFF
--- a/vagrant/ansible/roles/ctdb.setup/tasks/main.yml
+++ b/vagrant/ansible/roles/ctdb.setup/tasks/main.yml
@@ -47,11 +47,11 @@
     permanent: yes
     state: enabled
 
-- name: Add recovery lock to ctdb.conf
+- name: Add cluster lock to ctdb.conf
   lineinfile:
     dest: /etc/ctdb/ctdb.conf
-    line: "\trecovery lock = /gluster/lock/recovery.lock"
-    regexp: "recovery lock"
+    line: "\tcluster lock = /gluster/lock/cluster.lock"
+    regexp: "cluster lock"
     insertafter: '\[cluster\]'
 
 - name: Enable check consistency of databases during startup


### PR DESCRIPTION
Since [v4.16 release](https://www.samba.org/samba/history/samba-4.16.0.html) CTDB renamed "recovery lock" to "cluster lock". Therefore use "cluster lock" in ctdb.conf replacing "recovery lock".