### PR TITLE
Failure when updating CentOS 8 vagrant vms.

### DIFF
--- a/vagrant/roles/local.defaults/tasks/centos8.yml
+++ b/vagrant/roles/local.defaults/tasks/centos8.yml
@@ -1,2 +1,2 @@
-vagrant_image: "centos/stream8"
+vagrant_image: "generic/centos8s"
 actions_file: "centos8.yml"


### PR DESCRIPTION
Changes in the rpm package specs required that the rpm package has to be updated first before we can updated the rest.

This doesn't seem to cause a problem in the CentOS environment which seems to use an updated centos8 image. However this does cause problems in devel environments when performing updates of the centos8 virtual machines.