### PR TITLE
client.prep: Add pytest for clients

### DIFF
--- a/vagrant/ansible/roles/client.prep/tasks/centos7.yml
+++ b/vagrant/ansible/roles/client.prep/tasks/centos7.yml
@@ -6,6 +6,7 @@
       - python-pip
       - git
       - make
+      - python3-pytest
     state: latest
 
 - name: Install Python 3 modules
@@ -15,3 +16,9 @@
       - PyYAML
       - iso8601
     extra_args: --ignore-installed
+
+- name: Link to pytest
+  file:
+    src: /usr/bin/pytest-3
+    dest: /usr/local/bin/pytest
+    state: link

--- a/vagrant/ansible/roles/client.prep/tasks/centos8.yml
+++ b/vagrant/ansible/roles/client.prep/tasks/centos8.yml
@@ -6,6 +6,7 @@
       - python3-pip
       - git
       - make
+      - python3-pytest
     state: latest
 
 - name: Install Python 3 modules
@@ -15,3 +16,9 @@
       - PyYAML
       - iso8601
     extra_args: --ignore-installed
+
+- name: Link to pytest
+  file:
+    src: /usr/bin/pytest-3
+    dest: /usr/local/bin/pytest
+    state: link


### PR DESCRIPTION
We also symlink /usrt/local/bin/pytest to
/usr/bin/pytest-3

This will be used as a test runner for sit-test-cases