### PR TITLE
client.test.prep: Change test directory to sit-test-cases

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -41,7 +41,7 @@ client.test:
 setup.site: setup.cluster setup.clients generate.report client.test
 
 client1.test:
-	@$(VSSH) clients "sudo make -C /root/samba-integration-tests test"
+	@$(VSSH) clients "sudo make -C /root/sit-test-cases test"
 
 clean_vagrant:
 	-$(VAGRANT) destroy -f

--- a/vagrant/ansible/roles/client.test.prep/tasks/main.yml
+++ b/vagrant/ansible/roles/client.test.prep/tasks/main.yml
@@ -4,13 +4,13 @@
       git:
         repo: "{{ test_repo }}"
         version: "{{ test_repo_branch }}"
-        dest: /root/samba-integration-tests
+        dest: /root/sit-test-cases
 
     - name: Fetching PR
       git:
         repo: "{{ test_repo }}"
         refspec: +pull/{{ test_repo_pr }}/head:pr{{ test_repo_pr }}
-        dest: /root/samba-integration-tests
+        dest: /root/sit-test-cases
 
     - set_fact:
         test_repo_branch: "pr{{ test_repo_pr }}"
@@ -23,12 +23,12 @@
   git:
     repo: "{{ test_repo }}"
     version: "{{ test_repo_branch }}"
-    dest: /root/samba-integration-tests
+    dest: /root/sit-test-cases
 
 - name: Create a symlink for test-info.yml file
   file:
     src: /root/test-info.yml
-    dest: /root/samba-integration-tests/test-info.yml
+    dest: /root/sit-test-cases/test-info.yml
     owner: root
     group: root
     state: link

--- a/vagrant/ansible/roles/client.test/tasks/main.yml
+++ b/vagrant/ansible/roles/client.test/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Run tests
   command:
-    chdir: /root/samba-integration-tests
+    chdir: /root/sit-test-cases
     cmd: make test
   when: test_sanity_only is undefined
 
 - name: Run sanity tests
   command:
-    chdir: /root/samba-integration-tests
+    chdir: /root/sit-test-cases
     cmd: make sanity_test
   when: test_sanity_only is defined


### PR DESCRIPTION
Change the directory in which the sit-test-cases are cloned from samba-integration-tests to
sit-test-cases