### PR TITLE
client.test: print test output

### DIFF
--- a/vagrant/ansible/roles/client.test/tasks/main.yml
+++ b/vagrant/ansible/roles/client.test/tasks/main.yml
@@ -1,12 +1,18 @@
 ---
 - name: Run tests
-  command:
-    chdir: /root/sit-test-cases
-    cmd: make test
+  block:
+    - command:
+        chdir: /root/sit-test-cases
+        cmd: make test
+      register: test_output
+    - debug: var=test_output.stdout_lines
   when: test_sanity_only is undefined
 
 - name: Run sanity tests
-  command:
-    chdir: /root/sit-test-cases
-    cmd: make sanity_test
+  block:
+    - command:
+        chdir: /root/sit-test-cases
+        cmd: make sanity_test
+      register: test_output
+    - debug: var=test_output.stdout_lines
   when: test_sanity_only is defined


### PR DESCRIPTION
At the moment, if the tests are successful, the output is not printed. With the planned performance tests, we would like the output printed even when the tests are successful.