### PR TITLE
Remove OS and backend name mappings

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -31,17 +31,6 @@ file:
 Update `vagrant/roles/local.defaults/vars/main.yml` to add the following
 information:
 
-  - Add the internal name in `be_names` object.
-
-    This entry maps the user-provided backend name into a name that will be
-    used internally to locate files related to that backend.
-
-    Example:
-      ```yaml
-      be_names:
-        glusterfs: glusterfs
-      ```
-
   - Create an environment for the new backend in `environments` object.
 
     You need to define how many machines are needed to run the tests, as well
@@ -56,9 +45,6 @@ Create a new role `sit.<backend>` in `vagrant/roles` that will be responsible
 to install any required packages needed to install the backend components in
 the required machines. This commonly includes any extra ansible collections
 that will help during the installation.
-
-> Note: the name of the `<backend>` must be the internal one defined in the
->       `be_names` object in the previous step.
 
 The tasks must be created in `tasks/setup/main.yml` under the role's main
 directory.

--- a/vagrant/roles/local.defaults/templates/config.yml.j2
+++ b/vagrant/roles/local.defaults/templates/config.yml.j2
@@ -1,8 +1,7 @@
 ---
 config:
   os:
-    id: "{{ os }}"
-    name: "{{ os_names[os] }}"
+    name: "{{ os }}"
     includes: {{ os_includes[os] }}
     vagrant:
     {%- if vagrant.pool is defined +%}
@@ -11,8 +10,7 @@ config:
       image: "{{ vagrant.images[os] }}"
 
   be:
-    id: "{{ be }}"
-    name: "{{ be_names[be] }}"
+    name: "{{ be }}"
 
   data: {{ environments[be].data | default({}) }}
 

--- a/vagrant/roles/local.defaults/vars/main.yml
+++ b/vagrant/roles/local.defaults/vars/main.yml
@@ -1,11 +1,5 @@
 ---
 
-# This maps the name used externally in the 'use_distro' variable into an
-# internal constant name.
-os_names:
-  centos7: centos7
-  centos8: centos8
-
 # This defines the potential files to locate for OS-dependent tasks. They are
 # sorted in order of priority, with the highest priority at the top. Only the
 # first file found is processed.
@@ -20,13 +14,6 @@ os_includes:
     - centos.yml
     - redhat.yml
     - generic.yml
-
-# This maps the name use externally in the 'backend' variable into an internal
-# constant name.
-be_names:
-  glusterfs: glusterfs
-  xfs: xfs
-  cephfs: cephfs
 
 # Vagrant/VM global settings
 vagrant:


### PR DESCRIPTION
The mapping is really unnecessary because the name is always mapped to itself.