### PR TITLE
Add OS properties in configuration

### DIFF
--- a/vagrant/roles/local.defaults/templates/config.yml.j2
+++ b/vagrant/roles/local.defaults/templates/config.yml.j2
@@ -2,7 +2,13 @@
 config:
   os:
     name: "{{ os }}"
-    includes: {{ os_includes[os] }}
+    family: "{{ os_info[os].family }}"
+    distro: "{{ os_info[os].distro }}"
+    version: "{{ os_info[os].version }}"
+    includes:
+      - "{{ os_info[os].distro }}{{ os_info[os].version}}.yml"
+      - "{{ os_info[os].distro }}.yml"
+      - "{{ os_info[os].family }}.yml"
     vagrant:
     {%- if vagrant.pool is defined +%}
       pool: "{{ vagrant.pool }}"

--- a/vagrant/roles/local.defaults/vars/main.yml
+++ b/vagrant/roles/local.defaults/vars/main.yml
@@ -1,19 +1,17 @@
 ---
 
-# This defines the potential files to locate for OS-dependent tasks. They are
-# sorted in order of priority, with the highest priority at the top. Only the
-# first file found is processed.
-os_includes:
+# This determines the properties of each OS so that it can be used for better
+# conditionals and reduce duplication in some places.
+os_info:
   centos7:
-    - centos7.yml
-    - centos.yml
-    - redhat.yml
-    - generic.yml
+    family: redhat
+    distro: centos
+    version: 7
+
   centos8:
-    - centos8.yml
-    - centos.yml
-    - redhat.yml
-    - generic.yml
+    family: redhat
+    distro: centos
+    version: 8
 
 # Vagrant/VM global settings
 vagrant:


### PR DESCRIPTION
Some properties for each supported OS are added so that they can be used in conditionals and other places. This can help reduce code duplication.