### PR TITLE
Install 'tox' package

### DIFF
--- a/vagrant/ansible/roles/client.prep/tasks/centos.yml
+++ b/vagrant/ansible/roles/client.prep/tasks/centos.yml
@@ -10,6 +10,7 @@
       - make
       - python3-pytest
       - podman
+      - tox
     state: latest
 
 - name: Install Python 3 modules


### PR DESCRIPTION
When running sit-tests-cases we need python's tox utility.