### PR TITLE
Add ansible.cfg

### DIFF
--- a/vagrant/ansible.cfg
+++ b/vagrant/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+any_errors_fatal = True
+callbacks_enabled = profile_tasks

--- a/vagrant/ansible/ansible.cfg
+++ b/vagrant/ansible/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+any_errors_fatal = True
+callbacks_enabled = profile_tasks


### PR DESCRIPTION
Create an ansible.cfg file to configure ansible's playbooks behavior:

  - Fail immediately as soon as any task fails

    By default ansible continues executing tasks as long as at least one host has succeeded. In out environment this doesn't make sense because we need all hosts prepared to run tests.

  - Add timing

    This will be useful to know at which time each task has started and be able to match it with logs in case of issues. It will also give an idea of which tasks consume more time, which can be used to try to optimize the playbooks.