### PR TITLE
sit.glusterfs: Install ansible collections with --no-cache

### DIFF
--- a/vagrant/roles/sit.glusterfs/tasks/setup/centos.yml
+++ b/vagrant/roles/sit.glusterfs/tasks/setup/centos.yml
@@ -19,7 +19,7 @@
   block:
     - name: Install ansible collections
       become: no
-      shell: ansible-galaxy collection install {{ item }}
+      shell: ansible-galaxy collection install --no-cache {{ item }}
       loop:
         - ansible.posix
         - community.general


### PR DESCRIPTION
Recently the following error is seen while trying to install ansible collections:

> [WARNING]: Skipping Galaxy server https://galaxy.ansible.com/api/. Got
  an unexpected error when getting available versions of collection community.general:
  '/api/v3/plugin/ansible/content/published/collections/index/community/general/versions/'
ERROR! Unexpected Exception, this is probably a bug:
  '/api/v3/plugin/ansible/content/published/collections/index/community/general/versions/'

We are already stuck with ansible version from 2.12.x series due to another [issue](https://github.com/gluster/gluster-ansible-infra/issues/135) from gluster-ansible-infra and fix for the above error is only available from [v2.12.8](https://github.com/ansible/ansible/issues/81830#issuecomment-1743199288). Given that the fixed version is out for a while and updates are not yet released via repositories we could only keep it running with a workaround of disabling the cache while fetching the versions for a particular collection as described in upstream [issue](https://github.com/ansible/ansible/issues/77911#issuecomment-1149780261).