### PR TITLE
sit.glusterfs/setup: Install latest available ansible version

### DIFF
--- a/vagrant/roles/sit.glusterfs/tasks/setup/centos.yml
+++ b/vagrant/roles/sit.glusterfs/tasks/setup/centos.yml
@@ -5,9 +5,7 @@
 - name: Install gluster-ansible
   yum:
     name:
-      # Restricting to Ansible v2.12.x
-      # See https://github.com/gluster/gluster-ansible-infra/issues/135
-      - ansible-core-2.12*
+      - ansible-core
       - gluster-ansible-cluster
       - gluster-ansible-features
       - gluster-ansible-infra
@@ -15,19 +13,11 @@
       - gluster-ansible-repositories
     state: latest
 
-- name: Install required ansible collections and dependencies
-  block:
-    - name: Install ansible collections
-      become: no
-      shell: ansible-galaxy collection install --no-cache {{ item }}
-      loop:
-        - ansible.posix
-        - community.general
-        - gluster.gluster
-        - ovirt.ovirt
-
-    - name: Install ansible collection dependencies
-      pip:
-        name: jmespath
-        executable: pip3.8
-        state: latest
+- name: Install required ansible collections
+  become: no
+  shell: ansible-galaxy collection install {{ item }}
+  loop:
+    - ansible.posix
+    - community.general
+    - gluster.gluster
+    - ovirt.ovirt

--- a/vagrant/roles/sit.glusterfs/tasks/setup/centos8.yml
+++ b/vagrant/roles/sit.glusterfs/tasks/setup/centos8.yml
@@ -1,0 +1,9 @@
+---
+- name: Process common OS tasks
+  include_tasks: centos.yml
+
+- name: Install Python jmespath module
+  yum:
+    name:
+      - python3.11-jmespath
+    state: latest

--- a/vagrant/roles/sit.glusterfs/tasks/setup/centos9.yml
+++ b/vagrant/roles/sit.glusterfs/tasks/setup/centos9.yml
@@ -1,0 +1,9 @@
+---
+- name: Process common OS tasks
+  include_tasks: centos.yml
+
+- name: Install Python jmespath module
+  yum:
+    name:
+      - python3-jmespath
+    state: latest


### PR DESCRIPTION
Now that the required [fixes](https://github.com/gluster/gluster-ansible-infra/pull/136) are in for gluster-ansible we could use latest ansible packages.