### PR TITLE
Force a failure if some test fails

### DIFF
--- a/playbooks/ansible/roles/tests/tasks/main.yml
+++ b/playbooks/ansible/roles/tests/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Initialize test result
+  set_fact:
+    tests_failed: false
+
 - name: Run tests
   include_tasks: run-test.yml
   vars:
@@ -6,3 +10,8 @@
   loop: "{{ config.tests }}"
   loop_control:
     loop_var: test_name
+
+- name: Check that tests succeeded
+  when: tests_failed
+  fail:
+    msg: "Some tests have failed"

--- a/playbooks/ansible/roles/tests/tasks/run-test.yml
+++ b/playbooks/ansible/roles/tests/tasks/run-test.yml
@@ -31,6 +31,10 @@
         name: "{{ role }}"
         tasks_from: recover/main.yml
 
+    - name: Mark the test as failed
+      set_fact:
+        tests_failed: true
+
   always:
     - name: Log test finalization time
       include_tasks: log.yml


### PR DESCRIPTION
The current approach detects failures but does continue with other tests. This is problematic because the ansible playbook execution completes successfully while there could have been some failed tests.

This patch forces a failure when any test fails. This will fix the issue until a better test failure reporting is implemented.

fixes #51 