### PR TITLE
statedump: Few cleanup changes

### DIFF
--- a/playbooks/roles/config.collect/tasks/main.yml
+++ b/playbooks/roles/config.collect/tasks/main.yml
@@ -12,6 +12,7 @@
 - name: Copy test configuration data
   shell: cp /root/test-info.yml {{ config.configdir }}
   when: inventory_hostname in groups['clients']
+  ignore_errors: true
 
 - name: Copy configuration directory
   synchronize:

--- a/playbooks/roles/local.defaults/templates/config.yml.j2
+++ b/playbooks/roles/local.defaults/templates/config.yml.j2
@@ -70,5 +70,5 @@ config:
     {%- endfor +%}
   {%- endfor +%}
 
-  statedir: "{{ misc.host.statedir }}/sit.{{ be }}_statedump"
+  statedir: "{{ misc.host.statedir }}/sit.{{ backend }}_statedump"
   configdir: "{{ misc.host.configdir }}"


### PR DESCRIPTION
* Instead of processed backend name use the raw `backend` environment variable value for better discovery of statedir.
  - Such a change was the missing piece, especially with `cephfs.vfs` where jenkins used to search for _/tmp/sit.cephfs.vfs_statedump_ but the actual directory is named _sit.cephfs_statedump_.
* In those situations where environment was not setup correctly we fail to run any tests. This would mean that test-info.yml file is not linked and subsequent task to copy it fails. Therefore make sure that we collect rest of the logs and configuration by ignoring the errors while copying the test-info file.