### PR TITLE
devel: fix inventory symlink

### DIFF
--- a/devel/inventory
+++ b/devel/inventory
@@ -1,1 +1,1 @@
-../vagrant/vagrant_ansible_inventory
+../playbooks/site_inventory


### PR DESCRIPTION
Fix symlink to inventory in the devel directory. This allows us to use the ansible scripts in the devel directory.