### PR TITLE
tests: Fix the location of site-tests.log

### DIFF
--- a/playbooks/ansible/roles/tests/tasks/log.yml
+++ b/playbooks/ansible/roles/tests/tasks/log.yml
@@ -1,6 +1,5 @@
 ---
 - name: Add a log entry to site-tests.log
-  delegate_to: localhost
   block:
     - name: Get current time
       command: date "+%Y-%m-%d %H-%M-%S.%3N"
@@ -8,7 +7,7 @@
 
     - name: Write the log entry to site-tests.log
       lineinfile:
-        dest: "{{ config.statedir }}/site-tests.log"
+        dest: /var/log/site-tests.log
         line: "{{ now.stdout }} {{ line }}"
         insertafter: EOF
         create: true


### PR DESCRIPTION
Since we copy the required playbooks from host, _site-tests.log_ was always created within setup machine. As a result statedump process failed to copy it from setup machine. Therefore allow it to be created under _/var/log_ so that statedump process can collect it from the client machine.