### PR TITLE
cluster-glusterfs: Disable disperse volume operations

### DIFF
--- a/playbooks/ansible/cluster-glusterfs.yml
+++ b/playbooks/ansible/cluster-glusterfs.yml
@@ -60,22 +60,6 @@ replicate_cluster_options:
   performance.readdir-ahead: 'on'
   performance.parallel-readdir: 'on'
 
-disperse_cluster_volume: "vol-disperse"
-disperse_cluster_disperse_count: 3
-disperse_cluster_bricks: '/bricks/brick-disp-0/vol,/bricks/brick-disp-1/vol,/bricks/brick-disp-2/vol'
-disperse_cluster_options:
-  features.cache-invalidation: 'on'
-  features.cache-invalidation-timeout: '600'
-  performance.cache-samba-metadata: 'on'
-  performance.stat-prefetch: 'on'
-  performance.cache-invalidation: 'on'
-  performance.md-cache-timeout: '600'
-  network.inode-lru-limit: '200000'
-  performance.nl-cache: 'on'
-  performance.nl-cache-timeout: '600'
-  performance.readdir-ahead: 'on'
-  performance.parallel-readdir: 'on'
-
 ctdb_network_private_interfaces: >-
   {{
     config.nodes |
@@ -104,4 +88,3 @@ samba_users:
 
 samba_shares:
   - { cluster_volume: "vol-replicate", share_name: "replicate" }
-  - { cluster_volume: "vol-disperse", share_name: "disperse" }

--- a/playbooks/ansible/roles/sit.glusterfs/tasks/main.yml
+++ b/playbooks/ansible/roles/sit.glusterfs/tasks/main.yml
@@ -16,17 +16,6 @@
   vars:
     volume:
       name: "{{ replicate_cluster_volume }}"
-      type: "replicate"
       backends: "{{ replicate_cluster_bricks }}"
       replica_count: "{{ replicate_cluster_replica_count }}"
       options: "{{ replicate_cluster_options }}"
-
-- include_tasks:
-    file: new_volume.yml
-  vars:
-    volume:
-      name: "{{ disperse_cluster_volume }}"
-      type: "disperse"
-      backends: "{{ disperse_cluster_bricks }}"
-      disperse_count: "{{ disperse_cluster_disperse_count }}"
-      options: "{{ disperse_cluster_options }}"

--- a/playbooks/ansible/roles/sit.glusterfs/tasks/new_volume.yml
+++ b/playbooks/ansible/roles/sit.glusterfs/tasks/new_volume.yml
@@ -7,18 +7,6 @@
     cluster: "{{ config.groups['cluster'] }}"
     replicas: "{{ volume.replica_count }}"
   run_once: yes
-  when: volume.type == 'replicate'
-
-- name: Create Dispersed Volumes
-  gluster_volume:
-    state: present
-    name: "{{ volume.name }}"
-    bricks: "{{ volume.backends }}"
-    cluster: "{{ config.groups['cluster'] }}"
-    disperses: "{{ volume.disperse_count }}"
-    force: yes
-  run_once: yes
-  when: volume.type == 'disperse'
 
 - name: Set volume options
   gluster_volume:


### PR DESCRIPTION
Test runs on disperse volumes doesn't proceed after a hung state and eventually gets timed out(6 hrs from CentOS CI maximum reservation time). Therefore limit the tests runs to just distribute-replicated volumes which seems to pass without any issues.