### PR TITLE
Dynamically adjust the amount of memory and CPUs assigned to each VM

### DIFF
--- a/playbooks/roles/local.defaults/tasks/main.yml
+++ b/playbooks/roles/local.defaults/tasks/main.yml
@@ -12,6 +12,7 @@
     be: "{{ (backend | default('glusterfs') | split('.'))[0] }}"
     variant: "{{ (backend | default('glusterfs') | split('.'))[1] | default('default') }}"
     max_memory: "{{ ansible_memfree_mb }}"
+    max_cpu: "{{ ansible_processor_nproc }}"
 
 - name: Load configuration
   include_vars:

--- a/playbooks/roles/local.defaults/tasks/main.yml
+++ b/playbooks/roles/local.defaults/tasks/main.yml
@@ -11,6 +11,7 @@
     os: "{{ use_distro | default('centos9') }}"
     be: "{{ (backend | default('glusterfs') | split('.'))[0] }}"
     variant: "{{ (backend | default('glusterfs') | split('.'))[1] | default('default') }}"
+    max_memory: "{{ ansible_memfree_mb }}"
 
 - name: Load configuration
   include_vars:

--- a/playbooks/roles/local.defaults/templates/config.yml.j2
+++ b/playbooks/roles/local.defaults/templates/config.yml.j2
@@ -38,19 +38,30 @@ config:
   {%- endfor +%}
 
 {%- set total_mem = max_memory * ((memory | default(resources.memory | default(50))) | int) / 100 +%}
+{%- set total_cpu = max_cpu * ((cpu | default(resources.cpu | default(100))) | int) / 100 +%}
 {%- set extra_mem = 0 +%}
+{%- set extra_cpu = 0 +%}
 {%- set base_mem = [] +%}
+{%- set base_cpu = [] +%}
 {%- set weight_mem = [] +%}
+{%- set weight_cpu = [] +%}
 {%- for name in environments[be].nodes +%}
 {%-   set data = environments[be].nodes[name] +%}
 {%-   set count = data.instances | default(1) +%}
 {%-   set _ = base_mem.append(count * (data.memory | default(environments[be].memory))) +%}
+{%-   set _ = base_cpu.append(count * (data.cpus | default(environments[be].cpus))) +%}
 {%-   set _ = weight_mem.append(count * (data.memory_weight | default(1))) +%}
+{%-   set _ = weight_cpu.append(count * (data.cpu_weight | default(1))) +%}
 {%- endfor +%}
 {%- set base_mem = base_mem | sum +%}
+{%- set base_cpu = base_cpu | sum +%}
 {%- set weight_mem = weight_mem | sum +%}
+{%- set weight_cpu = weight_cpu | sum +%}
 {%- if weight_mem > 0 +%}
 {%-   set extra_mem = ([ total_mem - base_mem, 0] | max) / weight_mem / 1024 +%}
+{%- endif +%}
+{%- if weight_cpu > 0 +%}
+{%-   set extra_cpu = ([ total_cpu - base_cpu, 0] | max) / weight_cpu +%}
 {%- endif +%}
 
   nodes:
@@ -62,7 +73,7 @@ config:
       groups: {{ data.groups }}
       provisioner: {{ prov }}
       os: {{ data.os | default(environments[be].os | default(os)) }}
-      cpus: {{ data.cpus | default(environments[be].cpus) }}
+      cpus: {{ (data.cpus | default(environments[be].cpus)) + ((extra_cpu * (data.cpu_weight | default(1))) | int) }}
       memory: {{ (data.memory | default(environments[be].memory)) + 1024 * ((extra_mem * (data.memory_weight | default(1))) | int) }}
       disks: {{ data.disks | default([]) }}
       networks:

--- a/playbooks/roles/local.defaults/templates/config.yml.j2
+++ b/playbooks/roles/local.defaults/templates/config.yml.j2
@@ -37,6 +37,22 @@ config:
       {%- endfor +%}
   {%- endfor +%}
 
+{%- set total_mem = max_memory * ((memory | default(resources.memory | default(50))) | int) / 100 +%}
+{%- set extra_mem = 0 +%}
+{%- set base_mem = [] +%}
+{%- set weight_mem = [] +%}
+{%- for name in environments[be].nodes +%}
+{%-   set data = environments[be].nodes[name] +%}
+{%-   set count = data.instances | default(1) +%}
+{%-   set _ = base_mem.append(count * (data.memory | default(environments[be].memory))) +%}
+{%-   set _ = weight_mem.append(count * (data.memory_weight | default(1))) +%}
+{%- endfor +%}
+{%- set base_mem = base_mem | sum +%}
+{%- set weight_mem = weight_mem | sum +%}
+{%- if weight_mem > 0 +%}
+{%-   set extra_mem = ([ total_mem - base_mem, 0] | max) / weight_mem / 1024 +%}
+{%- endif +%}
+
   nodes:
   {%- for name in environments[be].nodes +%}
     {%- set data = environments[be].nodes[name] +%}
@@ -47,7 +63,7 @@ config:
       provisioner: {{ prov }}
       os: {{ data.os | default(environments[be].os | default(os)) }}
       cpus: {{ data.cpus | default(environments[be].cpus) }}
-      memory: {{ data.memory | default(environments[be].memory) }}
+      memory: {{ (data.memory | default(environments[be].memory)) + 1024 * ((extra_mem * (data.memory_weight | default(1))) | int) }}
       disks: {{ data.disks | default([]) }}
       networks:
       {%- for net in data.networks | default({}) +%}

--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -18,6 +18,36 @@ misc:
     statedir: "/tmp"
     configdir: "/tmp/config"
 
+resources:
+  # Percentage of free memory that will be used for sit-environment by default.
+  # It can be overriden by setting the `memory` extra variable.
+  #
+  # All VMs are guaranteed to use the minimum memory defined, even if this
+  # makes them use more than the amount of memory defined here.
+  #
+  # The actual amount of memory assigned to each VM is computed by dynamically
+  # distributing the portion of the free memory assigned to sit-environment
+  # proportionally based on the memory weight of each VM.
+  #
+  # B: Sum of the minimum memory assigned to each VM.
+  # T: Sum of the weights assigned to each VM.
+  # G: Total available memory to sit-environment, which is equal to the total
+  #    free memory multiplied by the defined percentage.
+  # Mi: Total memory assigned to i-th VM.
+  # mi: Minimum memory assigned to i-th VM.
+  # wi: Weight assigned to i-th VM.
+  #
+  # Mi = mi + int(max(G - B, 0) * wi / T)
+  #
+  # Examples with 50% memory utilization and 1 GiB minimum:
+  #
+  #           Weight  58 GiB Free    38 GiB Free    18 GiB Free    8 GiB Free
+  # setup0:      0       1 GiB          1 GiB          1 GiB         1 GiB
+  # client0:     1       6 GiB          4 GiB          2 GiB         1 GiB
+  # storage0:    2      11 GiB          7 GiB          3 GiB         1 GiB
+  # storage1:    2      11 GiB          7 GiB          3 GiB         1 GiB
+  memory: 50
+
 # List of tests to run
 tests:
   - sit-test-cases
@@ -54,8 +84,8 @@ provisioners:
 #     overridden by specific VM type definitions.
 #
 #   memory: (required)
-#     Default amount of memory (in MiB) assigned to each VM. This value
-#     can be overridden by specific VM type definitions.
+#     Default minimum amount of memory (in MiB) assigned to each VM. This
+#     value can be overridden by specific VM type definitions.
 #
 #   data: (optional, default: {})
 #     This field contains any extra data specific to the environment that
@@ -84,7 +114,13 @@ provisioners:
 #     Number of CPUs for this specific VM type.
 #
 #   memory: (optional, default: the value of `memory` in the environment)
-#     Amount of memory for this specific VM type.
+#     Minimum amount of memory for this specific VM type.
+#
+#   memory_weight: (optional, default: 1)
+#     Relative weight of the memory assigned to this VM type. A higher weight
+#     will assign more memory to this VM type. A value of 0 will use just the
+#     minimum memory defined by the `memory` option. See the comment in the
+#     `resources` section to see how this value works.
 #
 #   disks: (optional, default: [])
 #     List of additional disks for this type of VM (besides the system
@@ -108,12 +144,12 @@ provisioners:
 environments:
   glusterfs:
     cpus: 8
-    memory: 8192
+    memory: 1024
 
     nodes:
       setup:
         cpus: 2
-        memory: 1024
+        memory_weight: 0
         networks:
           private: 200
         groups: [admin]
@@ -121,13 +157,14 @@ environments:
 
       client:
         cpus: 4
-        memory: 4096
+        memory_weight: 1
         networks:
           public: 5
         groups: [clients]
 
       storage:
         instances: 2
+        memory_weight: 2
         disks: [10, 10, 10]
         networks:
           private: 100
@@ -139,17 +176,18 @@ environments:
 
   xfs:
     cpus: 4
-    memory: 4096
+    memory: 1024
 
     nodes:
       setup:
         cpus: 2
-        memory: 1024
+        memory_weight: 0
         networks:
           private: 200
         groups: [admin]
 
       storage:
+        memory_weight: 1
         disks: [10]
         networks:
           private: 100
@@ -159,13 +197,14 @@ environments:
         groups: [cluster]
 
       client:
+        memory_weight: 1
         networks:
           public: 5
         groups: [clients]
 
   cephfs:
     cpus: 8
-    memory: 8192
+    memory: 1024
 
     data:
       branch: main
@@ -173,13 +212,14 @@ environments:
     nodes:
       setup:
         cpus: 2
-        memory: 1024
+        memory_weight: 0
         networks:
           private: 200
         groups: [admin]
 
       storage:
         instances: 3
+        memory_weight: 2
         disks: [10, 10, 10]
         networks:
           private: 100
@@ -190,7 +230,7 @@ environments:
 
       client:
         cpus: 4
-        memory: 4096
+        memory_weight: 1
         networks:
           public: 5
         groups: [clients]

--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -48,6 +48,15 @@ resources:
   # storage1:    2      11 GiB          7 GiB          3 GiB         1 GiB
   memory: 50
 
+  # Percentage of the cores that will be used for sit-environment by default.
+  # It can be overriden by setting the `cpu` extra variable.
+  #
+  # This is equivalent to the `memory` option but applied to CPU cores.
+  #
+  # It's allowed to use a value higher than 100% assuming that some VMs will
+  # actually not use all the cores at 100%.
+  cpu: 100
+
 # List of tests to run
 tests:
   - sit-test-cases
@@ -80,7 +89,7 @@ provisioners:
 #     be overriden by specific VM type definitions.
 #
 #   cpus: (required)
-#     Default number of CPUs to assign to each VM. This value can be
+#     Default minimum number of CPUs to assign to each VM. This value can be
 #     overridden by specific VM type definitions.
 #
 #   memory: (required)
@@ -111,7 +120,13 @@ provisioners:
 #     Defines how many VMs of this type will be created.
 #
 #   cpus: (optional, default: the value of `cpus` in the environment)
-#     Number of CPUs for this specific VM type.
+#     Minimum number of CPUs for this specific VM type.
+#
+#   cpu_weight: (optional, default: 1)
+#     Relative weight of the number of CPUs assigned to this VM type. A higher
+#     weight will assign more CPUs to this VM type. A value of 0 will use just
+#     the minimum number of CPUs defined by the `cpus` option. See the comment
+#     in the `resources` section to see how this value works.
 #
 #   memory: (optional, default: the value of `memory` in the environment)
 #     Minimum amount of memory for this specific VM type.
@@ -143,12 +158,12 @@ provisioners:
 #
 environments:
   glusterfs:
-    cpus: 8
+    cpus: 2
     memory: 1024
 
     nodes:
       setup:
-        cpus: 2
+        cpu_weight: 0
         memory_weight: 0
         networks:
           private: 200
@@ -156,7 +171,7 @@ environments:
         os: centos8
 
       client:
-        cpus: 4
+        cpu_weight: 1
         memory_weight: 1
         networks:
           public: 5
@@ -164,6 +179,7 @@ environments:
 
       storage:
         instances: 2
+        cpu_weight: 2
         memory_weight: 2
         disks: [10, 10, 10]
         networks:
@@ -175,18 +191,19 @@ environments:
         os: centos8
 
   xfs:
-    cpus: 4
+    cpus: 2
     memory: 1024
 
     nodes:
       setup:
-        cpus: 2
+        cpu_weight: 0
         memory_weight: 0
         networks:
           private: 200
         groups: [admin]
 
       storage:
+        cpu_weight: 1
         memory_weight: 1
         disks: [10]
         networks:
@@ -197,13 +214,14 @@ environments:
         groups: [cluster]
 
       client:
+        cpu_weight: 1
         memory_weight: 1
         networks:
           public: 5
         groups: [clients]
 
   cephfs:
-    cpus: 8
+    cpus: 2
     memory: 1024
 
     data:
@@ -211,7 +229,7 @@ environments:
 
     nodes:
       setup:
-        cpus: 2
+        cpu_weight: 0
         memory_weight: 0
         networks:
           private: 200
@@ -219,6 +237,7 @@ environments:
 
       storage:
         instances: 3
+        cpu_weight: 2
         memory_weight: 2
         disks: [10, 10, 10]
         networks:
@@ -229,7 +248,7 @@ environments:
         groups: [cluster]
 
       client:
-        cpus: 4
+        cpu_weight: 1
         memory_weight: 1
         networks:
           public: 5


### PR DESCRIPTION
This patch provides a way to automatically assign a portion of the memory and CPUs to the sit-environment and proportionally distribute it among the VMs that will be created based on a per-VM weight defined in the environment configuration.

Two new extra vars have been defined that can override how many resources are assigned to sit-environment:

`memory`: Percentage of the free memory assigned to sit-environment (default: 50)
`cpu`: Percentage of the available cores assigned to sit-environment (default: 100)