### PR TITLE
client-test: Disable printing test output

### DIFF
--- a/playbooks/ansible/Makefile
+++ b/playbooks/ansible/Makefile
@@ -17,7 +17,7 @@ generate.report:
 	@ansible-playbook -i $(INVENTORY) ${ANSIBLE_EXTRA_VARS} ./generate-report.yml
 
 client.test:
-	@ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook -i $(INVENTORY) ${ANSIBLE_EXTRA_VARS} ./client-test.yml
+	@ansible-playbook -i $(INVENTORY) ${ANSIBLE_EXTRA_VARS} ./client-test.yml
 
 setup.site: setup.cluster setup.clients client.test
 

--- a/playbooks/ansible/roles/test.sit-test-cases/tasks/main.yml
+++ b/playbooks/ansible/roles/test.sit-test-cases/tasks/main.yml
@@ -1,18 +1,12 @@
 ---
 - name: Run tests
-  block:
-    - shell:
-        chdir: /root/sit-test-cases
-        cmd: make test &> /var/log/test.out
-      register: test_output
-    - debug: var=test_output.stdout_lines
+  shell:
+    chdir: /root/sit-test-cases
+    cmd: make test &> /var/log/test.out
   when: test_sanity_only is undefined
 
 - name: Run sanity tests
-  block:
-    - shell:
-        chdir: /root/sit-test-cases
-        cmd: make sanity_test &> /var/log/test.out
-      register: test_output
-    - debug: var=test_output.stdout_lines
+  shell:
+    chdir: /root/sit-test-cases
+    cmd: make sanity_test &> /var/log/test.out
   when: test_sanity_only is defined


### PR DESCRIPTION
* smbtorture tests have been configured in https://github.com/samba-in-kubernetes/sit-test-cases/pull/44 to print the results irrespective of the outcome.
* Test output is now redirected to a separate file in https://github.com/samba-in-kubernetes/sit-environment/pull/67, additional debug lines from ansible are no longer required.

Previous change from 15b8f6179f204c4ee3cce755e7fcc4498e0fe9d3 to configure `ANSIBLE_STDOUT_CALLBACK` option can also be avoided as entire results are now available in a separate file.

depends on #67 