### PR TITLE
sit.xfs: Copy Samba-CTDB configuration from cluster nodes

### DIFF
--- a/playbooks/roles/sit.xfs/tasks/config/main.yml
+++ b/playbooks/roles/sit.xfs/tasks/config/main.yml
@@ -1,1 +1,7 @@
 ---
+- name: Copy necessary configuration directories
+  shell: cp -r {{ item }} {{ config.configdir }}
+  with_items:
+    - /etc/samba
+    - /etc/ctdb
+  when: inventory_hostname in groups['cluster']


### PR DESCRIPTION
`sit.xfs` role failed to include _/etc/samba_ and _/etc/ctdb_ configuration directories during statedump process.