### PR TITLE
test.sit-test-cases: Redirect test output to a file

### DIFF
--- a/playbooks/ansible/roles/test.sit-test-cases/tasks/main.yml
+++ b/playbooks/ansible/roles/test.sit-test-cases/tasks/main.yml
@@ -1,18 +1,18 @@
 ---
 - name: Run tests
   block:
-    - command:
+    - shell:
         chdir: /root/sit-test-cases
-        cmd: make test
+        cmd: make test &> /var/log/test.out
       register: test_output
     - debug: var=test_output.stdout_lines
   when: test_sanity_only is undefined
 
 - name: Run sanity tests
   block:
-    - command:
+    - shell:
         chdir: /root/sit-test-cases
-        cmd: make sanity_test
+        cmd: make sanity_test &> /var/log/test.out
       register: test_output
     - debug: var=test_output.stdout_lines
   when: test_sanity_only is defined


### PR DESCRIPTION
Instead of cluttering the jenkins job console output with detailed test results we could redirect everything to a separate file and make it available as artifacts for each job. Simplest way to achieve this redirection is to make use of `&>`(see [section 3.6.4 bash manual](https://www.gnu.org/software/bash/manual/html_node/Redirections.html)) to include both STDOUT and STDERR. Location of such an output file is chosen to be under _/var/log_ so that it also gets collected as part of statedump process.
