### PR TITLE
playbooks: Remove unused shell script

### DIFF
--- a/playbooks/environment.sh
+++ b/playbooks/environment.sh
@@ -1,3 +1,0 @@
-# source me
-export ANSIBLE_INVENTORY=site_inventory
-


### PR DESCRIPTION
_environment.sh_ contains just an `export` statement for `ANSIBLE_INVENTORY` variable. It was added in 6dfc2a4952673bf1e369f5ba5d66a7c83f5866f4 to better work with vagrant environments. But these days inventory file is always specified as part of playbook execution command. Therefore remove `environment.sh` from sources.