### PR TITLE
local.defaults: Redefine statedump directory name

### DIFF
--- a/playbooks/roles/local.defaults/templates/config.yml.j2
+++ b/playbooks/roles/local.defaults/templates/config.yml.j2
@@ -99,5 +99,5 @@ config:
     {%- endfor +%}
   {%- endfor +%}
 
-  statedir: "{{ misc.host.statedir }}/sit.{{ backend }}_statedump"
+  statedir: "{{ misc.host.statedir }}/sit_statedump"
   configdir: "{{ misc.host.configdir }}"


### PR DESCRIPTION
Make targets when invoked without explicit mention of `backend` variable leaves behind a single occurrence in config.yml.j2 causing the following failure:

> TASK [local.defaults : Generate config.yml in ansible directory] An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'backend' is undefined. 'backend' is undefined
fatal: [localhost]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'backend' is undefined. 'backend' is undefined"}

Therefore redefine statedump directory name to "sit_statedump".

fixes #72 