### PR TITLE
local.defaults: Change default backend to XFS

### DIFF
--- a/playbooks/roles/local.defaults/tasks/main.yml
+++ b/playbooks/roles/local.defaults/tasks/main.yml
@@ -9,8 +9,8 @@
     dest: ./ansible/config.yml
   vars:
     os: "{{ use_distro | default('centos9') }}"
-    be: "{{ (backend | default('glusterfs') | split('.'))[0] }}"
-    variant: "{{ (backend | default('glusterfs') | split('.'))[1] | default('default') }}"
+    be: "{{ (backend | default('xfs') | split('.'))[0] }}"
+    variant: "{{ (backend | default('xfs') | split('.'))[1] | default('default') }}"
     max_memory: "{{ ansible_memfree_mb }}"
     max_cpu: "{{ ansible_processor_nproc }}"
 


### PR DESCRIPTION
It has been a while since XFS was added to the list of supported backends and is known to successfully complete full test runs. On the other side GlusterFS is going through tough times in getting necessary fixes for long pending failures. Let's flip the switch and change the default backend from GlusterFS to XFS.