### PR TITLE
Make definition of users and groups configurable inside settings.yml

### DIFF
--- a/playbooks/ansible/cluster-cephfs.yml
+++ b/playbooks/ansible/cluster-cephfs.yml
@@ -19,9 +19,6 @@ ctdb_network_public_interface_subnet_mask: "24"
 ctdb_network_public_interface_name: "eth2"
 
 samba_netbios_name: "SIT-CEPHFS-TEST"
-samba_users:
-  - { username: 'test1', password: 'x', uid: '2001' }
-  - { username: 'test2', password: 'x', uid: '2002' }
 
 samba_shares:
   - { cluster_volume: "samba", share_name: "share" }

--- a/playbooks/ansible/cluster-glusterfs.yml
+++ b/playbooks/ansible/cluster-glusterfs.yml
@@ -98,9 +98,6 @@ ctdb_cluster_volume: "ctdb"
 ctdb_cluster_replica_count: "{{ config.groups['cluster']|length }}"
 
 samba_netbios_name: "SIT-GLUSTERFS-TEST"
-samba_users:
-  - { username: 'test1', password: 'x', uid: '2001' }
-  - { username: 'test2', password: 'x', uid: '2002' }
 
 samba_shares:
   - { cluster_volume: "vol-replicate", share_name: "replicate" }

--- a/playbooks/ansible/cluster-xfs.yml
+++ b/playbooks/ansible/cluster-xfs.yml
@@ -19,9 +19,6 @@ ctdb_network_public_interface_subnet_mask: "24"
 ctdb_network_public_interface_name: "eth2"
 
 samba_netbios_name: "SIT-XFS-TEST"
-samba_users:
-  - { username: 'test1', password: 'x', uid: '2001' }
-  - { username: 'test2', password: 'x', uid: '2002' }
 
 samba_shares:
   - { cluster_volume: "samba", share_name: "share", device: "/dev/vdb" }

--- a/playbooks/ansible/roles/client.prep/tasks/main.yml
+++ b/playbooks/ansible/roles/client.prep/tasks/main.yml
@@ -24,5 +24,4 @@
     exported_sharenames: >-
       {{ samba_shares | map(attribute='share_name') |
       map('regex_replace', '$', '-' + config.be.name + '-' + config.be.variant) | list }}
-    test_users: "{{ samba_users }}"
     test_backend: "{{ config.be.name }}"

--- a/playbooks/ansible/roles/client.prep/tasks/main.yml
+++ b/playbooks/ansible/roles/client.prep/tasks/main.yml
@@ -14,14 +14,6 @@
 - debug:
     msg: "{{ ctdb_network_public_interfaces }}"
 
-- name: Create a README file
-  template:
-    src: README.j2
-    dest: /root/README
-    owner: root
-    group: root
-    mode: '0644'
-
 - name: Create the test-info.yml file with test cluster information
   template:
     src: test-info.yml.j2

--- a/playbooks/ansible/roles/client.prep/templates/README.j2
+++ b/playbooks/ansible/roles/client.prep/templates/README.j2
@@ -1,5 +1,0 @@
-Welcome to client1
-
-- The setup contains {{ ctdb_network_public_interfaces|length }} public ip addresses which are accessible from the clients on hostname testhost[0..n]
-- There are {{ samba_users|length }} test users available.
-- The SMB mounts are available to mount in /test-mnt/<hostname>/<username> and the /etc/fstab entries have already been added.

--- a/playbooks/ansible/roles/client.prep/templates/test-info.yml.j2
+++ b/playbooks/ansible/roles/client.prep/templates/test-info.yml.j2
@@ -8,6 +8,16 @@ exported_sharenames:
   {{ exported_sharenames | to_nice_yaml | indent(2) }}
 
 test_users:
-  {{ test_users | to_nice_yaml | indent(2) }}
+  {%- for name in config.accounts +%}
+    {%- for user_name in config.accounts[name].users +%}
+      {%- set user = config.accounts[name].users[user_name] +%}
+      {%- if user.samba +%}
+  - username: {{ user_name }}
+    uid: {{ user.uid }}
+    password: {{ user.password }}
+    nodes: {{ config.nodes | dict2items | selectattr('value.accounts', 'contains', name) | map(attribute='key') | list }}
+      {%- endif +%}
+    {%- endfor +%}
+  {%- endfor +%}
 
 test_backend: {{ test_backend }}

--- a/playbooks/ansible/roles/ctdb.setup/tasks/main.yml
+++ b/playbooks/ansible/roles/ctdb.setup/tasks/main.yml
@@ -100,8 +100,3 @@
   until: nodestatus.rc == 0
   retries: 20
   delay: 3
-
-- name: Create test users with smbpasswd
-  shell: (echo {{ item.password }}; echo {{ item.password }})|smbpasswd -a {{ item.username }}
-  with_items: "{{ samba_users }}"
-  run_once: yes

--- a/playbooks/ansible/roles/samba.setup/tasks/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/main.yml
@@ -71,10 +71,3 @@
 - name: Update selinux contexts
   command: restorecon -R "{{ config.paths.mount }}/{{ item.cluster_volume }}"
   loop: "{{ samba_shares }}"
-
-- name: Create test users
-  user:
-    name: "{{ item.username }}"
-    uid: "{{ item.uid }}"
-    state: present
-  with_items: "{{ samba_users }}"

--- a/playbooks/ansible/roles/users.setup/tasks/create_users.yml
+++ b/playbooks/ansible/roles/users.setup/tasks/create_users.yml
@@ -1,0 +1,7 @@
+---
+- name: Create Samba user
+  shell: >-
+    (echo {{ accounts[item].password }}; echo {{ accounts[item].password }}) |
+      smbpasswd -a {{ item }}
+  when: accounts[item].samba
+  with_items: "{{ accounts }}"

--- a/playbooks/ansible/roles/users.setup/tasks/main.yml
+++ b/playbooks/ansible/roles/users.setup/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Process samba users
+  include_tasks: create_users.yml
+  vars:
+    accounts: "{{ config.accounts[account_group].users }}"
+  when:
+    - config.accounts[account_group].users
+    - account_group in config.nodes[inventory_hostname].accounts
+  with_items: "{{ config.accounts }}"
+  loop_control:
+    loop_var: account_group
+  run_once: yes

--- a/playbooks/ansible/setup-cluster.yml
+++ b/playbooks/ansible/setup-cluster.yml
@@ -11,3 +11,4 @@
     - "sit.{{ config.be.name }}"
     - samba.setup
     - ctdb.setup
+    - users.setup

--- a/playbooks/roles/hosts.update/tasks/create_groups.yml
+++ b/playbooks/roles/hosts.update/tasks/create_groups.yml
@@ -1,0 +1,7 @@
+---
+- name: Create group
+  group:
+    name: "{{ item }}"
+    gid: "{{ accounts[item] }}"
+    state: present
+  with_items: "{{ accounts }}"

--- a/playbooks/roles/hosts.update/tasks/create_users.yml
+++ b/playbooks/roles/hosts.update/tasks/create_users.yml
@@ -1,0 +1,11 @@
+---
+- name: Create user
+  user:
+    name: "{{ item }}"
+    uid: "{{ accounts[item].uid }}"
+    password: "{{ accounts[item].password | password_hash }}"
+    group: "{{ accounts[item].primary_group | default(omit) }}"
+    comment: "{{ accounts[item].comment | default(omit) }}"
+    groups: "{{ accounts[item].groups | default(omit) }}"
+    state: present
+  with_items: "{{ accounts }}"

--- a/playbooks/roles/hosts.update/tasks/main.yml
+++ b/playbooks/roles/hosts.update/tasks/main.yml
@@ -5,3 +5,25 @@
     - files: "{{ config.os[config.nodes[inventory_hostname].os].includes }}"
   loop_control:
     loop_var: include_file
+
+- name: Process group accounts
+  include_tasks: create_groups.yml
+  vars:
+    accounts: "{{ config.accounts[account_group].groups }}"
+  when:
+    - config.accounts[account_group].groups
+    - account_group in config.nodes[inventory_hostname].accounts
+  with_items: "{{ config.accounts }}"
+  loop_control:
+    loop_var: account_group
+
+- name: Process user accounts
+  include_tasks: create_users.yml
+  vars:
+    accounts: "{{ config.accounts[account_group].users }}"
+  when:
+    - config.accounts[account_group].users
+    - account_group in config.nodes[inventory_hostname].accounts
+  with_items: "{{ config.accounts }}"
+  loop_control:
+    loop_var: account_group

--- a/playbooks/roles/local.defaults/templates/config.yml.j2
+++ b/playbooks/roles/local.defaults/templates/config.yml.j2
@@ -20,6 +20,54 @@ config:
 
   paths: {{ paths }}
 
+  accounts:
+  {%- for name in accounts | default({}) +%}
+    {{ name }}:
+      groups:
+    {%- for group in accounts[name].groups | default({}) +%}
+      {%- set acct = accounts[name].groups[group] +%}
+      {%- for idx in range(acct.instances | default(1)) +%}
+        {%- set group_name = group +%}
+        {%- if acct.instances is defined +%}
+          {%- set group_name = group ~ (idx + 1) +%}
+        {%- endif +%}
+        {{ group_name }}: {{ acct.gid + idx }}
+      {%- endfor +%}
+    {%- endfor +%}
+      users:
+    {%- for user in accounts[name].users | default({}) +%}
+      {%- set acct = accounts[name].users[user] +%}
+      {%- for idx in range(acct.instances | default(1)) +%}
+        {%- set user_name = user +%}
+        {%- if acct.instances is defined +%}
+          {%- set user_name = user ~ (idx + 1) +%}
+        {%- endif +%}
+        {{ user_name }}:
+          uid: {{ acct.uid + idx }}
+          {%- if acct.primary_group is defined +%}
+          primary_group: {{ acct.primary_group }}
+          {%- endif +%}
+          password: {{ acct.password | default(user_name) }}
+          {%- if acct.comment is defined +%}
+          comment: {{ acct.comment }}
+          {%- endif +%}
+          {%- if acct.groups | default(false) +%}
+          groups:
+            {%- for group in acct.groups | default([]) +%}
+              {%- if accounts[name].groups[group].instances is defined +%}
+                {%- for idx in range(accounts[name].groups[group].instances) +%}
+            - {{ group }}{{ idx + 1}}
+                {%- endfor +%}
+              {%- else +%}
+            - {{ group }}
+              {%- endif +%}
+            {%- endfor +%}
+          {%- endif +%}
+          samba: {{ acct.samba | default('false') }}
+      {%- endfor +%}
+    {%- endfor +%}
+  {%- endfor +%}
+
   tests: {{ tests }}
 
   provisioners:
@@ -86,6 +134,7 @@ config:
       {%- for net in data.ctdb | default({}) +%}
         {{ net }}: {{ provisioners[prov].networks[net] | ansible.utils.ipaddr(data.ctdb[net] + idx) | ansible.utils.ipaddr('address') }}
       {%- endfor +%}
+      accounts: {{ data.accounts | default([]) }}
     {%- endfor +%}
   {%- endfor +%}
 

--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -29,6 +29,85 @@ paths:
 
   mount: /mnt
 
+# Creation of accounts:
+#
+# Here are defined lists of groups and users, that are to be created in the test
+# nodes. Since it must be possible to define different accounts in different
+# types of machines, all definitions are created inside named objects, which
+# will later be referenced from the 'environment' object.
+#
+# Groups are created inside the 'groups' sub-object. Each group has the
+# following properties:
+#
+#   gid: (required)
+#     The GID number to assign to this group account.
+#
+#   instances: (optional)
+#     Number of group accounts to create using these properties. If not present,
+#     a regular group will be created. If present, a number of groups will be
+#     created using the same data but modifying the following properties:
+#
+#       gid: The first group will be assigned the gid specified, but it will be
+#            incremented by one for each new group.
+#
+#       name: The name of the group will be suffixed by an incrementing index,
+#             starting from 1.
+#
+# Note: default group names (those with the same name as the user), don't need
+#       to be defined. They are created automatically. This object is intended
+#       to create supplementary groups.
+#
+# Users are created inside the 'users' sub-object. Each user has the following
+# properties:
+#
+#   uid: (required)
+#     The UID number to assign to this user account.
+#
+#   primary_group: (optional, default: a group with the same name as the user)
+#     The primary group to assign to the user account. If present, it must be
+#     defined in the 'groups' object.
+#
+#     The name cannot reference a template group (one defined with the
+#     'instances' value). If the primary group belongs to a template group,
+#     then the index must also be included as part of the name.
+#
+#   password: (optional, default: the name of the user)
+#     The password to assign to the user account.
+#
+#   comment: (optional)
+#     A comment to assign to the user account.
+#
+#   groups: (optional)
+#     A list of supplementary groups that will be assigned to the user account.
+#     All of them must be defined in the 'groups' object.
+#
+#     If a name references a template group (one defined with the 'instances'
+#     value), then the user is made member of all groups from the template.
+#
+#   instances: (optional)
+#     Number of user accounts to create using these properties. If not present,
+#     a regular user will be created. If present, a number of users will be
+#     created using the same data but modifying the following properties:
+#
+#       uid: The first user will be assigned the uid specified, but it will be
+#            incremented by one for each new user.
+#
+#       name: The name of the user will be suffixed by an incrementing index,
+#             starting from 1.
+#
+#   samba: (optional, default: false)
+#     Boolean that indicates if this user will be created in samba. This only
+#     has effect if the target node has samba installed. Otherwise it's ignored.
+#
+accounts:
+  default:
+    users:
+      test:
+        uid: 2001
+        password: x
+        instances: 2
+        samba: true
+
 resources:
   # Percentage of free memory that will be used for sit-environment by default.
   # It can be overridden by setting the `memory` extra variable.
@@ -167,6 +246,10 @@ provisioners:
 #     List of ansible group names where the VMs of this type will be
 #     assigned to.
 #
+#   accounts: (optional)
+#     List of predefined account objects that will be used to create groups
+#     and users for this specific VM type.
+#
 environments:
   glusterfs:
     cpus: 2
@@ -200,6 +283,7 @@ environments:
           public: 10
         groups: [cluster]
         os: centos8
+        accounts: [default]
 
   xfs:
     cpus: 2
@@ -223,6 +307,7 @@ environments:
         ctdb:
           public: 10
         groups: [cluster]
+        accounts: [default]
 
       client:
         cpu_weight: 1
@@ -257,6 +342,7 @@ environments:
         ctdb:
           public: 10
         groups: [cluster]
+        accounts: [default]
 
       client:
         cpu_weight: 1

--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -31,7 +31,7 @@ paths:
 
 resources:
   # Percentage of free memory that will be used for sit-environment by default.
-  # It can be overriden by setting the `memory` extra variable.
+  # It can be overridden by setting the `memory` extra variable.
   #
   # All VMs are guaranteed to use the minimum memory defined, even if this
   # makes them use more than the amount of memory defined here.
@@ -60,7 +60,7 @@ resources:
   memory: 50
 
   # Percentage of the cores that will be used for sit-environment by default.
-  # It can be overriden by setting the `cpu` extra variable.
+  # It can be overridden by setting the `cpu` extra variable.
   #
   # This is equivalent to the `memory` option but applied to CPU cores.
   #
@@ -93,11 +93,11 @@ provisioners:
 #
 #   provisioner: (optional, default: 'vagrant')
 #     Default provisioner used to provision the hosts of the environment.
-#     This value can be overriden by specific VM type definitions.
+#     This value can be overridden by specific VM type definitions.
 #
 #   os: (optional, default: `use_distro` if defined, 'centos9' otherwise)
 #     Default OS installed on all hosts of the environment. This value can
-#     be overriden by specific VM type definitions.
+#     be overridden by specific VM type definitions.
 #
 #   cpus: (required)
 #     Default minimum number of CPUs to assign to each VM. This value can be


### PR DESCRIPTION
Instead of defining users inside the private configuration of each backend, the definition has been moved to the global _setting.yml_ file. Additionally, now it's also possible to define groups and group membership.

To support cases where we want a lot of users and/or groups, it's also possible to define them in a very compact way.