### PR TITLE
Make backend filesystems available from client machines

### DIFF
--- a/playbooks/ansible/cluster-glusterfs.yml
+++ b/playbooks/ansible/cluster-glusterfs.yml
@@ -44,38 +44,6 @@ gluster_infra_fw_zone: public
 gluster_infra_fw_services:
   - glusterfs
 
-replicate_cluster_volume: "vol-replicate"
-replicate_cluster_replica_count: "{{ config.groups['cluster']|length }}"
-replicate_cluster_bricks: '/bricks/brick-repl-0/vol,/bricks/brick-repl-1/vol,/bricks/brick-repl-2/vol'
-replicate_cluster_options:
-  features.cache-invalidation: 'on'
-  features.cache-invalidation-timeout: '600'
-  performance.cache-samba-metadata: 'on'
-  performance.stat-prefetch: 'on'
-  performance.cache-invalidation: 'on'
-  performance.md-cache-timeout: '600'
-  network.inode-lru-limit: '200000'
-  performance.nl-cache: 'on'
-  performance.nl-cache-timeout: '600'
-  performance.readdir-ahead: 'on'
-  performance.parallel-readdir: 'on'
-
-disperse_cluster_volume: "vol-disperse"
-disperse_cluster_disperse_count: 3
-disperse_cluster_bricks: '/bricks/brick-disp-0/vol,/bricks/brick-disp-1/vol,/bricks/brick-disp-2/vol'
-disperse_cluster_options:
-  features.cache-invalidation: 'on'
-  features.cache-invalidation-timeout: '600'
-  performance.cache-samba-metadata: 'on'
-  performance.stat-prefetch: 'on'
-  performance.cache-invalidation: 'on'
-  performance.md-cache-timeout: '600'
-  network.inode-lru-limit: '200000'
-  performance.nl-cache: 'on'
-  performance.nl-cache-timeout: '600'
-  performance.readdir-ahead: 'on'
-  performance.parallel-readdir: 'on'
-
 ctdb_network_private_interfaces: >-
   {{
     config.nodes |
@@ -105,8 +73,41 @@ samba_shares:
     samba:
       options:
         "acl_xattr:ignore system acls": "yes"
+    glusterfs:
+      type: "replicate"
+      subvolume_size: "{{ config.groups['cluster']|length }}"
+      bricks: '/bricks/brick-repl-0/vol,/bricks/brick-repl-1/vol,/bricks/brick-repl-2/vol'
+      options:
+        features.cache-invalidation: 'on'
+        features.cache-invalidation-timeout: '600'
+        performance.cache-samba-metadata: 'on'
+        performance.stat-prefetch: 'on'
+        performance.cache-invalidation: 'on'
+        performance.md-cache-timeout: '600'
+        network.inode-lru-limit: '200000'
+        performance.nl-cache: 'on'
+        performance.nl-cache-timeout: '600'
+        performance.readdir-ahead: 'on'
+        performance.parallel-readdir: 'on'
+
   - cluster_volume: "vol-disperse"
     share_name: "disperse"
     samba:
       options:
         "acl_xattr:ignore system acls": "yes"
+    glusterfs:
+      type: "disperse"
+      subvolume_size: 3
+      bricks: '/bricks/brick-disp-0/vol,/bricks/brick-disp-1/vol,/bricks/brick-disp-2/vol'
+      options:
+        features.cache-invalidation: 'on'
+        features.cache-invalidation-timeout: '600'
+        performance.cache-samba-metadata: 'on'
+        performance.stat-prefetch: 'on'
+        performance.cache-invalidation: 'on'
+        performance.md-cache-timeout: '600'
+        network.inode-lru-limit: '200000'
+        performance.nl-cache: 'on'
+        performance.nl-cache-timeout: '600'
+        performance.readdir-ahead: 'on'
+        performance.parallel-readdir: 'on'

--- a/playbooks/ansible/roles/client.prep/tasks/centos.yml
+++ b/playbooks/ansible/roles/client.prep/tasks/centos.yml
@@ -11,6 +11,7 @@
       - python3-pytest
       - podman
       - tox
+      - sshfs
     state: latest
 
 - name: Link to pytest

--- a/playbooks/ansible/roles/client.prep/tasks/main.yml
+++ b/playbooks/ansible/roles/client.prep/tasks/main.yml
@@ -14,6 +14,19 @@
 - debug:
     msg: "{{ ctdb_network_public_interfaces }}"
 
+- name: Create backend mount points
+  file:
+    path: "{{ config.paths.mount }}/backends/{{ item.share_name }}-{{ config.be.name }}-{{ config.be.variant }}"
+    state: directory
+  with_items: "{{ samba_shares }}"
+
+- name: Make the backend filesystems accessible from the client
+  command: >-
+    sshfs -o reconnect
+      root@{{ config.groups['cluster'][0] }}:{{ config.paths.mount }}/{{ item.cluster_volume }}
+      {{ config.paths.mount }}/backends/{{ item.share_name }}-{{ config.be.name }}-{{ config.be.variant }}
+  with_items: "{{ samba_shares }}"
+
 - name: Create the test-info.yml file with test cluster information
   template:
     src: test-info.yml.j2

--- a/playbooks/ansible/roles/common.prep/tasks/main.yml
+++ b/playbooks/ansible/roles/common.prep/tasks/main.yml
@@ -13,18 +13,31 @@
 
 - name: create ansible directory (for ssh key)
   file:
-    path: ansible
+    path: /root/ansible
     state: directory
 
 - name: copy ssh key
   copy:
     src: insecure_private_ssh_key
-    dest: ansible/insecure_private_ssh_key
+    dest: /root/ansible/insecure_private_ssh_key
+    mode: 0600
+
+- name: Create .ssh directory
+  file:
+    path: /root/.ssh
+    state: directory
+    mode: 0700
 
 - name: copy ssh config
   copy:
     src: ssh-config-setup
-    dest: .ssh/config
+    dest: /root/.ssh/config
+
+- name: Copy authorized_keys
+  copy:
+    src: ~/.ssh/authorized_keys
+    dest: /root/.ssh/authorized_keys
+    mode: 0600
 
 - name: Create /etc/hosts
   template:

--- a/playbooks/ansible/roles/ctdb.setup/tasks/cephfs/main.yml
+++ b/playbooks/ansible/roles/ctdb.setup/tasks/cephfs/main.yml
@@ -8,4 +8,3 @@
       name: "ctdb"
       path: "{{ ctdb_lock_path }}"
       mode: "0777"
-      mount: true

--- a/playbooks/ansible/roles/ctdb.setup/tasks/glusterfs/main.yml
+++ b/playbooks/ansible/roles/ctdb.setup/tasks/glusterfs/main.yml
@@ -24,7 +24,7 @@
       name: "{{ ctdb_cluster_volume }}"
       type: "replicate"
       backends: "{{ ctdb_brick_location }}/ctdb"
-      replica_count: "{{ ctdb_cluster_replica_count }}"
+      subvolume_size: "{{ ctdb_cluster_replica_count }}"
       mount: "{{ ctdb_lock_path }}"
       mount_opts: "_netdev,transport=tcp,xlator-option=*client*.ping-timeout=10"
 

--- a/playbooks/ansible/roles/sit.cephfs/tasks/main.yml
+++ b/playbooks/ansible/roles/sit.cephfs/tasks/main.yml
@@ -106,5 +106,4 @@
       name: "{{ item.share_name }}-{{ config.be.name }}-{{ config.be.variant }}"
       path: "{{ config.paths.mount }}/{{ item.cluster_volume }}"
       mode: "0777"
-      mount: "{{ config.be.variant == 'default' }}"
   loop: "{{ samba_shares }}"

--- a/playbooks/ansible/roles/sit.cephfs/tasks/new_volume.yml
+++ b/playbooks/ansible/roles/sit.cephfs/tasks/new_volume.yml
@@ -13,21 +13,18 @@
   retries: 100
   delay: 1
 
-- name: Mount the CephFS subvolume
-  when: volume.mount
-  block:
-    - name: Get the subvolume's path
-      command: >
-        /root/cephadm shell --
-          ceph fs subvolume getpath sit_fs {{ volume.name }}
-      run_once: true
-      register: ceph_subvol
+- name: Get the subvolume's path
+  command: >
+    /root/cephadm shell --
+      ceph fs subvolume getpath sit_fs {{ volume.name }}
+  run_once: true
+  register: ceph_subvol
 
-    - name: Create the mount
-      mount:
-        path: "{{ volume.path }}"
-        fstype: ceph
-        opts: "conf=/etc/ceph/sit.ceph.conf,name=sit"
-        src: "{{ config.nodes[config.groups['cluster'][0]].networks.private }}:6789:{{ ceph_subvol.stdout }}"
-        boot: false
-        state: mounted
+- name: Create the mount
+  mount:
+    path: "{{ volume.path }}"
+    fstype: ceph
+    opts: "conf=/etc/ceph/sit.ceph.conf,name=sit"
+    src: "{{ config.nodes[config.groups['cluster'][0]].networks.private }}:6789:{{ ceph_subvol.stdout }}"
+    boot: false
+    state: mounted

--- a/playbooks/ansible/roles/sit.glusterfs/tasks/main.yml
+++ b/playbooks/ansible/roles/sit.glusterfs/tasks/main.yml
@@ -15,18 +15,9 @@
     file: new_volume.yml
   vars:
     volume:
-      name: "{{ replicate_cluster_volume }}"
-      type: "replicate"
-      backends: "{{ replicate_cluster_bricks }}"
-      replica_count: "{{ replicate_cluster_replica_count }}"
-      options: "{{ replicate_cluster_options }}"
-
-- include_tasks:
-    file: new_volume.yml
-  vars:
-    volume:
-      name: "{{ disperse_cluster_volume }}"
-      type: "disperse"
-      backends: "{{ disperse_cluster_bricks }}"
-      disperse_count: "{{ disperse_cluster_disperse_count }}"
-      options: "{{ disperse_cluster_options }}"
+      name: "{{ item.cluster_volume }}"
+      type: "{{ item.glusterfs.type }}"
+      backends: "{{ item.glusterfs.bricks }}"
+      subvolume_size: "{{ item.glusterfs.subvolume_size }}"
+      options: "{{ item.glusterfs.options }}"
+  with_items: "{{ samba_shares }}"

--- a/playbooks/ansible/roles/sit.glusterfs/tasks/main.yml
+++ b/playbooks/ansible/roles/sit.glusterfs/tasks/main.yml
@@ -20,4 +20,5 @@
       backends: "{{ item.glusterfs.bricks }}"
       subvolume_size: "{{ item.glusterfs.subvolume_size }}"
       options: "{{ item.glusterfs.options }}"
+      mount: "{{ config.paths.mount }}/{{ item.cluster_volume }}"
   with_items: "{{ samba_shares }}"

--- a/playbooks/ansible/roles/sit.glusterfs/tasks/new_volume.yml
+++ b/playbooks/ansible/roles/sit.glusterfs/tasks/new_volume.yml
@@ -5,7 +5,7 @@
     name: "{{ volume.name }}"
     bricks: "{{ volume.backends }}"
     cluster: "{{ config.groups['cluster'] }}"
-    replicas: "{{ volume.replica_count }}"
+    replicas: "{{ volume.subvolume_size }}"
   run_once: yes
   when: volume.type == 'replicate'
 
@@ -15,7 +15,7 @@
     name: "{{ volume.name }}"
     bricks: "{{ volume.backends }}"
     cluster: "{{ config.groups['cluster'] }}"
-    disperses: "{{ volume.disperse_count }}"
+    disperses: "{{ volume.subvolume_size }}"
     force: yes
   run_once: yes
   when: volume.type == 'disperse'

--- a/playbooks/ansible/roles/sit.glusterfs/tasks/new_volume.yml
+++ b/playbooks/ansible/roles/sit.glusterfs/tasks/new_volume.yml
@@ -33,6 +33,5 @@
     path: "{{ volume.mount }}"
     src: "localhost:/{{ volume.name }}"
     fstype: glusterfs
-    opts: "{{ volume.mount_opts | default('') }}"
+    opts: "{{ volume.mount_opts | default(omit) }}"
     state: mounted
-  when: volume.mount is defined

--- a/playbooks/roles/provisioner.vagrant/tasks/create/main.yml
+++ b/playbooks/roles/provisioner.vagrant/tasks/create/main.yml
@@ -59,7 +59,7 @@
   replace:
     path: ./ansible/ssh-config-setup
     regexp: "IdentityFile .*"
-    replace: "IdentityFile ansible/insecure_private_ssh_key"
+    replace: "IdentityFile ~/ansible/insecure_private_ssh_key"
 
 - name: Create state directory structure on host
   file:


### PR DESCRIPTION
This PR makes it possible to directly access the backend filesystem from the client machines bypassing Samba layer.

This is exclusively created for testing purposes since bypassing Samba will most probably cause problems (multiprotocol access is not supported yet), but it will simplify the implementation of some tests.

The backend filesystems are mounted inside _/mnt/backends/_, in a subdirectory with the same name as the samba share.

This is currently implemented using SSHFS, which doesn't support extended attributes, so there may be limitations on what can be done directly on the backend. If needed, this can be improved in the future by using an NFSv4 mount instead of SSHFS.