### PR TITLE
samba.setup: Run cephfs.vfs integration with SELinux booleans

### DIFF
--- a/playbooks/ansible/roles/samba.setup/tasks/cephfs/centos.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/cephfs/centos.yml
@@ -1,0 +1,3 @@
+---
+- name: Install python3-libsemanage. This is needed for the seboolean ansible command
+  yum: name=python3-libsemanage state=present

--- a/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
@@ -2,15 +2,25 @@
 - name: Prepare CephFS VFS support
   when: config.be.variant == 'vfs'
   block:
+    - name: Process OS specific tasks
+      include_tasks: "{{ include_file }}"
+      with_first_found:
+        - files: "{{ config.os[config.nodes[inventory_hostname].os].includes }}"
+      loop_control:
+        loop_var: include_file
+
+    - name: SELinux - Allow Samba to do tcp socket operations
+      seboolean:
+        # Name of the boolean is misleading in this context.
+        # https://github.com/samba-in-kubernetes/sit-environment/issues/79
+        name: samba_load_libgfapi
+        state: yes
+        persistent: yes
+
     - name: Install CephFS VFS module
       yum:
         name: samba-vfs-cephfs
         state: present
-
-    - name: Set selinux in permissive mode
-      selinux:
-        policy: targeted
-        state: permissive
 
     - name: Skip check of share path
       lineinfile:


### PR DESCRIPTION
Upon investigation following are the only AVCs from audit logs blocking us from running CephFS VFS integration.

> type=AVC msg=audit(1706499792.666:8328): avc:  denied  { name_connect } for  pid=75570 comm="msgr-worker-1" dest=3300 scontext=system_u:system_r:smbd_t:s0 tcontext=system_u:object_r:unreserved_port_t:s0 tclass=tcp_socket permissive=1

Even though its misleading `samba_load_libgfapi` seems to be the only SELinux boolean that we require to run integration using VFS module for Ceph in Samba under Enforcing mode. This is clear from the allow rules defined for the boolean as follows:

```
$ sesearch -b samba_load_libgfapi -A
allow smbd_t packet_type:packet recv; [ samba_load_libgfapi ]:True
allow smbd_t packet_type:packet send; [ samba_load_libgfapi ]:True
allow smbd_t port_type:tcp_socket name_bind; [ samba_load_libgfapi ]:True
allow smbd_t port_type:tcp_socket name_connect; [ samba_load_libgfapi ]:True
```

Fixes #79 