### PR TITLE
smb_share.conf.j2: Add `ignore system acls` option to vfs_acl_xattr

### DIFF
--- a/playbooks/ansible/cluster-cephfs.yml
+++ b/playbooks/ansible/cluster-cephfs.yml
@@ -21,4 +21,8 @@ ctdb_network_public_interface_name: "eth2"
 samba_netbios_name: "SIT-CEPHFS-TEST"
 
 samba_shares:
-  - { cluster_volume: "samba", share_name: "share" }
+  - cluster_volume: "samba"
+    share_name: "share"
+    samba:
+      options:
+        "acl_xattr:ignore system acls": "yes"

--- a/playbooks/ansible/cluster-glusterfs.yml
+++ b/playbooks/ansible/cluster-glusterfs.yml
@@ -100,5 +100,13 @@ ctdb_cluster_replica_count: "{{ config.groups['cluster']|length }}"
 samba_netbios_name: "SIT-GLUSTERFS-TEST"
 
 samba_shares:
-  - { cluster_volume: "vol-replicate", share_name: "replicate" }
-  - { cluster_volume: "vol-disperse", share_name: "disperse" }
+  - cluster_volume: "vol-replicate"
+    share_name: "replicate"
+    samba:
+      options:
+        "acl_xattr:ignore system acls": "yes"
+  - cluster_volume: "vol-disperse"
+    share_name: "disperse"
+    samba:
+      options:
+        "acl_xattr:ignore system acls": "yes"

--- a/playbooks/ansible/cluster-xfs.yml
+++ b/playbooks/ansible/cluster-xfs.yml
@@ -21,4 +21,9 @@ ctdb_network_public_interface_name: "eth2"
 samba_netbios_name: "SIT-XFS-TEST"
 
 samba_shares:
-  - { cluster_volume: "samba", share_name: "share", device: "/dev/vdb" }
+  - cluster_volume: "samba"
+    share_name: "share"
+    device: "/dev/vdb"
+    samba:
+      options:
+        "acl_xattr:ignore system acls": "yes"

--- a/playbooks/ansible/roles/samba.setup/tasks/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/main.yml
@@ -57,6 +57,7 @@
         volume: "{{ item.cluster_volume }}"
         path: "{{ config.paths.mount }}/{{ item.cluster_volume }}"
         file: "{{ config.paths.samba.etc }}/smb.shares/{{ name }}.conf"
+        options: "{{ item.samba.options }}"
       with_items: "{{ samba_shares }}"
 
     - name: Include share configuration into smb.conf

--- a/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
+++ b/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
@@ -11,4 +11,9 @@ read only = no
 path = {{ subvol }}
 {%- else +%}
 path = {{ path }}
-{%- endif %}
+{%- endif +%}
+{%- if options is defined +%}
+{%- for option, value in options.items() +%}
+{{ option }} = {{ value }}
+{%- endfor +%}
+{%- endif +%}

--- a/playbooks/ansible/roles/sit.glusterfs/templates/smb_share.conf.j2
+++ b/playbooks/ansible/roles/sit.glusterfs/templates/smb_share.conf.j2
@@ -6,3 +6,8 @@ glusterfs:logfile = /var/log/samba/{{ name }}.%M.log
 glusterfs:loglevel = 7
 path = /
 read only = no
+{%- if options is defined +%}
+{%- for option, value in options.items() +%}
+{{ option }} = {{ value }}
+{%- endfor +%}
+{%- endif +%}

--- a/playbooks/ansible/roles/sit.xfs/templates/smb_share.conf.j2
+++ b/playbooks/ansible/roles/sit.xfs/templates/smb_share.conf.j2
@@ -3,3 +3,8 @@ comment = For samba share of volume {{ volume }}
 vfs objects = acl_xattr
 path = {{ path }}
 read only = no
+{%- if options is defined +%}
+{%- for option, value in options.items() +%}
+{{ option }} = {{ value }}
+{%- endfor +%}
+{%- endif +%}


### PR DESCRIPTION
For better coverage of smbtorture tests we require `ignore system acls` enabled for _acl_xattr_ VFS module. This is done to successfully complete those tests where such a lossy translation attempt from NT ACLs to POSIX ACLs would result in failures by design.

fixes #81 