### PR TITLE
client: do not use pip to install python modules

### DIFF
--- a/playbooks/ansible/roles/client.prep/tasks/centos.yml
+++ b/playbooks/ansible/roles/client.prep/tasks/centos.yml
@@ -13,14 +13,6 @@
       - tox
     state: latest
 
-- name: Install Python 3 modules
-  pip:
-    executable: /usr/bin/pip3
-    name:
-      - PyYAML
-      - iso8601
-    extra_args: --ignore-installed
-
 - name: Link to pytest
   file:
     src: /usr/bin/pytest-3


### PR DESCRIPTION
Since we have moved to using tox to run tests on the client, we can install the required dependencies from within tox. We do not need to use pip to install the modules on the clients.