### PR TITLE
Fixes to adjust with latest ansible v2.16.3

### DIFF
--- a/playbooks/ansible/roles/ctdb.setup/tasks/glusterfs/main.yml
+++ b/playbooks/ansible/roles/ctdb.setup/tasks/glusterfs/main.yml
@@ -10,8 +10,10 @@
 
 - name: Process OS specific tasks
   include_tasks: "{{ include_file }}"
+  vars:
+    prefix: "{{ role_path }}/tasks/glusterfs/"
   with_first_found:
-    - files: "{{ config.os[config.nodes[inventory_hostname].os].includes }}"
+    - files: "{{ [prefix] | product(config.os[config.nodes[inventory_hostname].os].includes) | map('join') | list }}"
   loop_control:
     loop_var: include_file
 

--- a/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
@@ -4,8 +4,10 @@
   block:
     - name: Process OS specific tasks
       include_tasks: "{{ include_file }}"
+      vars:
+        prefix: "{{ role_path }}/tasks/cephfs/"
       with_first_found:
-        - files: "{{ config.os[config.nodes[inventory_hostname].os].includes }}"
+        - files: "{{ [prefix] | product(config.os[config.nodes[inventory_hostname].os].includes) | map('join') | list }}"
       loop_control:
         loop_var: include_file
 

--- a/playbooks/ansible/roles/samba.setup/tasks/glusterfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/glusterfs/main.yml
@@ -1,8 +1,10 @@
 ---
 - name: Process OS specific tasks
   include_tasks: "{{ include_file }}"
+  vars:
+    prefix: "{{ role_path }}/tasks/glusterfs/"
   with_first_found:
-    - files: "{{ config.os[config.nodes[inventory_hostname].os].includes }}"
+    - files: "{{ [prefix] | product(config.os[config.nodes[inventory_hostname].os].includes) | map('join') | list }}"
   loop_control:
     loop_var: include_file
 

--- a/playbooks/ansible/roles/sit.cephfs/tasks/server/main.yml
+++ b/playbooks/ansible/roles/sit.cephfs/tasks/server/main.yml
@@ -1,8 +1,10 @@
 ---
 - name: Process OS specific tasks
   include_tasks: "{{ include_file }}"
+  vars:
+    prefix: "{{ role_path }}/tasks/server/"
   with_first_found:
-    - files: "{{ config.os[config.nodes[inventory_hostname].os].includes }}"
+    - files: "{{ [prefix] | product(config.os[config.nodes[inventory_hostname].os].includes) | map('join') | list }}"
   loop_control:
     loop_var: include_file
 

--- a/playbooks/roles/setup.prep/tasks/centos.yml
+++ b/playbooks/roles/setup.prep/tasks/centos.yml
@@ -9,16 +9,6 @@
     name: epel-release
     state: latest
 
-- name: Install Python3 pip
-  yum:
-    name: python3-pip
-    state: installed
-
-- name: Install pip jinja2 library
-  pip:
-    name: jinja2
-    state: latest
-
 # RHEL 8 image doesn't include make
 - name: Install additional packages
   yum:

--- a/playbooks/roles/setup.prep/tasks/centos8.yml
+++ b/playbooks/roles/setup.prep/tasks/centos8.yml
@@ -1,0 +1,13 @@
+---
+- name: Process common OS tasks
+  include_tasks: centos.yml
+
+- name: Install Python3.12 pip
+  yum:
+    name: python3.12-pip
+    state: installed
+
+- name: Install pip jinja2 library
+  pip:
+    executable: pip3.12
+    name: jinja2

--- a/playbooks/roles/setup.prep/tasks/centos9.yml
+++ b/playbooks/roles/setup.prep/tasks/centos9.yml
@@ -1,0 +1,12 @@
+---
+- name: Process common OS tasks
+  include_tasks: centos.yml
+
+- name: Install Python3 pip
+  yum:
+    name: python3-pip
+    state: installed
+
+- name: Install pip jinja2 library
+  pip:
+    name: jinja2

--- a/playbooks/roles/sit.cephfs/tasks/setup/centos8.yml
+++ b/playbooks/roles/sit.cephfs/tasks/setup/centos8.yml
@@ -1,6 +1,5 @@
 ---
 - name: Install Python jmespath module
-  yum:
-    name:
-      - python3.11-jmespath
-    state: latest
+  pip:
+    executable: pip3.12
+    name: jmespath

--- a/playbooks/roles/sit.cephfs/tasks/setup/centos9.yml
+++ b/playbooks/roles/sit.cephfs/tasks/setup/centos9.yml
@@ -1,6 +1,4 @@
 ---
 - name: Install Python jmespath module
-  yum:
-    name:
-      - python3-jmespath
-    state: latest
+  pip:
+    name: jmespath

--- a/playbooks/roles/sit.cephfs/tasks/setup/main.yml
+++ b/playbooks/roles/sit.cephfs/tasks/setup/main.yml
@@ -9,7 +9,9 @@
 
 - name: Process OS specific tasks
   include_tasks: "{{ include_file }}"
+  vars:
+    prefix: "{{ role_path }}/tasks/setup/"
   with_first_found:
-    - files: "{{ config.os[config.nodes[inventory_hostname].os].includes }}"
+    - files: "{{ [prefix] | product(config.os[config.nodes[inventory_hostname].os].includes) | map('join') | list }}"
   loop_control:
     loop_var: include_file

--- a/playbooks/roles/sit.glusterfs/tasks/setup/centos8.yml
+++ b/playbooks/roles/sit.glusterfs/tasks/setup/centos8.yml
@@ -3,7 +3,6 @@
   include_tasks: centos.yml
 
 - name: Install Python jmespath module
-  yum:
-    name:
-      - python3.11-jmespath
-    state: latest
+  pip:
+    executable: pip3.12
+    name: jmespath

--- a/playbooks/roles/sit.glusterfs/tasks/setup/centos9.yml
+++ b/playbooks/roles/sit.glusterfs/tasks/setup/centos9.yml
@@ -3,7 +3,5 @@
   include_tasks: centos.yml
 
 - name: Install Python jmespath module
-  yum:
-    name:
-      - python3-jmespath
-    state: latest
+  pip:
+    name: jmespath

--- a/playbooks/roles/sit.glusterfs/tasks/setup/main.yml
+++ b/playbooks/roles/sit.glusterfs/tasks/setup/main.yml
@@ -6,7 +6,9 @@
 
 - name: Process OS specific tasks
   include_tasks: "{{ include_file }}"
+  vars:
+    prefix: "{{ role_path }}/tasks/setup/"
   with_first_found:
-    - files: "{{ config.os[config.nodes[inventory_hostname].os].includes }}"
+    - files: "{{ [prefix] | product(config.os[config.nodes[inventory_hostname].os].includes) | map('join') | list }}"
   loop_control:
     loop_var: include_file


### PR DESCRIPTION
Very recently on CentOS Stream 8 ansible version got updated to _v2.16.3_ built with Python 3.12. Due to unavailability of python 3.12 module for _jmespath_ playbook execution is expected to fail. Therefore switch the python module installation from RPMs to pip where it can be versioned.

Additionally due to a regression in `first_found` plugin we switch to absolute paths wherever required to find OS specific files. See https://github.com/ansible/ansible/issues/82695 for more details.

depends on https://github.com/samba-in-kubernetes/samba-centosci/pull/54