### PR TITLE
cephfs/main.yml: Fix a yamllint warning

### DIFF
--- a/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
@@ -7,7 +7,8 @@
       vars:
         prefix: "{{ role_path }}/tasks/cephfs/"
       with_first_found:
-        - files: "{{ [prefix] | product(config.os[config.nodes[inventory_hostname].os].includes) | map('join') | list }}"
+        - files:
+            "{{ [prefix] | product(config.os[config.nodes[inventory_hostname].os].includes) | map('join') | list }}"
       loop_control:
         loop_var: include_file
 


### PR DESCRIPTION
warning:
playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
  10:121    warning  line too long (121 > 120 characters)  (line-length)