### PR TITLE
gpfs: Remove CentOS 8 requirement for clients

### DIFF
--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -389,7 +389,6 @@ environments:
       client:
         cpu_weight: 1
         memory_weight: 1
-        os: centos8
         networks:
           public: 5
         groups: [clients]


### PR DESCRIPTION
Client machines can very well run with CentOS 9 and higher. In fact [sit-test-cases](https://github.com/samba-in-kubernetes/sit-test-cases/) has a requirement for Python 3.9 which is by default available with CentOS 9.