### PR TITLE
Add support for 'gpfs.vfs' backend variant

### DIFF
--- a/playbooks/ansible/roles/samba.setup/tasks/gpfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/gpfs/main.yml
@@ -1,1 +1,12 @@
 ---
+- name: Run smbd unconfined
+  when: config.be.variant == 'vfs'
+  block:
+    - name: Configure SElinux context for smbd
+      sefcontext:
+        target: /usr/sbin/smbd
+        setype: bin_t
+        state: present
+
+    - name: Restore SElinux context
+      command: restorecon /usr/sbin/smbd

--- a/playbooks/ansible/roles/sit.gpfs/templates/smb_share.conf.j2
+++ b/playbooks/ansible/roles/sit.gpfs/templates/smb_share.conf.j2
@@ -1,6 +1,6 @@
 [{{ name }}-{{ config.be.name }}-{{ config.be.variant }}]
 comment = Volume '{{ name }}' from {{ config.be.name }}({{ config.be.variant }})
-vfs objects = acl_xattr
+vfs objects = acl_xattr {%- if config.be.variant == 'vfs' %} gpfs{% endif +%}
 path = {{ path }}
 read only = no
 {%- for option, value in volume.samba.options.items() | default([]) +%}


### PR DESCRIPTION
Now it's possible to use the 'vfs' variant of the GPFS backend. With it, the gpfs VFS module is automatically configured to be used by Samba.

The GPFS VFS module dynamically loads libgpfs.so library, which requires access to some resources that are not granted by default by SElinux. The Storage Scale product solves this by running smbd process unconfined, so the same solution has been applied here.