### PR TITLE
client: install the python3-smbc module

### DIFF
--- a/playbooks/ansible/roles/client.prep/tasks/centos.yml
+++ b/playbooks/ansible/roles/client.prep/tasks/centos.yml
@@ -12,6 +12,7 @@
       - podman
       - tox
       - sshfs
+      - python3-smbc
     state: latest
 
 - name: Link to pytest


### PR DESCRIPTION
This python module links to an external C library(libsmbclient) and is therefore very inconvenient to install using pip. We fall back to using the rpm package for this module.