### PR TITLE
Use default OS for GPFS storage nodes

### DIFF
--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -416,7 +416,7 @@ environments:
       setup:
         cpu_weight: 2
         memory_weight: 2
-        os: centos8
+        kernel: 5.14.0-503
         networks:
           private: 200
           public: 200
@@ -435,8 +435,8 @@ environments:
       storage:
         cpu_weight: 2
         memory_weight: 2
-        os: centos8
         instances: 2
+        kernel: 5.14.0-503
         disks: [10]
         networks:
           private: 50


### PR DESCRIPTION
This patch removes the requirement of CentOS 8 Stream for the storage nodes of the GPFS backend. That requirement was needed because of an incompatibility of the CentOS 9 Stream's ansible version and the ansible playbooks of the Storage Scale installer.

Updates: #102