### PR TITLE
Expose CephFS snapshots as shadow-copies

### DIFF
--- a/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
+++ b/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
@@ -1,6 +1,6 @@
 [{{ name }}-{{ config.be.name }}-{{ config.be.variant }}]
 comment = Volume '{{ name }}' from {{ config.be.name }}({{ config.be.variant }})
-vfs objects = acl_xattr
+vfs objects = acl_xattr ceph_snapshots
 {%- if config.be.variant == 'vfs' %} ceph
 ceph:config_file = /etc/ceph/sit.ceph.conf
 ceph:user_id = sit


### PR DESCRIPTION
Use kernel CephFS mounted share path to create the shadow copy using ceph_snapshots module

Refer: https://www.samba.org/samba/docs/4.11/man-html/vfs_ceph_snapshots.8.html