### PR TITLE
ceph: Add optional method to use RADOS helper to manage cluster lock

### DIFF
--- a/playbooks/ansible/roles/ctdb.setup/tasks/cephfs/main.yml
+++ b/playbooks/ansible/roles/ctdb.setup/tasks/cephfs/main.yml
@@ -7,3 +7,41 @@
   vars:
     name: "ctdb"
     path: "{{ ctdb_lock_path }}"
+
+- name: Configure RADOS mutex helper
+  when: config.data.ctdb_mutex == 'rados'
+  block:
+    - name: Create a user with rwx caps on dedicated pool
+      run_once: true
+      block:
+        - name: Create a dedicated pool
+          command: /root/cephadm shell -- ceph osd pool create ctdb
+
+        - name: Create a dedicated client
+          command: >
+            /root/cephadm shell --
+              ceph auth add client.ctdb mon 'allow r'
+                osd 'allow rwx pool=ctdb namespace=sit'
+
+    - name: Export keyring for client.ctdb
+      shell:
+        /root/cephadm shell --
+          ceph auth export client.ctdb > /etc/ceph/ceph.client.ctdb.keyring
+
+    - name: Update SELinux context for ceph configurations
+      command: restorecon -R /etc/ceph
+
+    - name: Allow CTDB to connect to mon over unreserved ports
+      seboolean:
+        name: nis_enabled
+        state: yes
+        persistent: yes
+
+    - name: Add RADOS mutex helper to ctdb.conf
+      ini_file:
+        path: "{{ config.paths.ctdb.etc }}/ctdb.conf"
+        section: cluster
+        option: cluster lock
+        value: '!/usr/libexec/ctdb/ctdb_mutex_ceph_rados_helper
+                  ceph client.ctdb ctdb cluster.lock -n sit'
+        state: present

--- a/playbooks/ansible/roles/ctdb.setup/tasks/cephfs/main.yml
+++ b/playbooks/ansible/roles/ctdb.setup/tasks/cephfs/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: Create the ctdb shared subvolume
+  when: config.data.ctdb_mutex is not defined
   include_role:
     name: 'sit.{{ config.be.name }}'
     tasks_from: new_volume

--- a/playbooks/ansible/roles/ctdb.setup/tasks/main.yml
+++ b/playbooks/ansible/roles/ctdb.setup/tasks/main.yml
@@ -15,6 +15,7 @@
       when: ctdb_network_public_interface_name is undefined
 
 - name: Create lock directory
+  when: config.data.ctdb_mutex is not defined
   file:
     path: "{{ config.paths.ctdb.var_lib }}/lock"
     state: directory
@@ -25,6 +26,7 @@
     ctdb_lock_path: "{{ config.paths.ctdb.var_lib }}/lock"
 
 - name: Update selinux contexts
+  when: config.data.ctdb_mutex is not defined
   command: restorecon -R "{{ config.paths.ctdb.var_lib }}/lock"
 
 - name: Check firewall

--- a/playbooks/ansible/roles/ctdb.setup/tasks/main.yml
+++ b/playbooks/ansible/roles/ctdb.setup/tasks/main.yml
@@ -53,6 +53,7 @@
     option: "{{ item.option }}"
     value: "{{ item.value }}"
     state: present
+  when: item.option != "cluster lock" or config.data.ctdb_mutex is not defined
   with_items:
     - section: cluster
       option: cluster lock

--- a/playbooks/ansible/roles/sit.cephfs/tasks/repo/centos.yml
+++ b/playbooks/ansible/roles/sit.cephfs/tasks/repo/centos.yml
@@ -1,7 +1,15 @@
 ---
-- name: Install CephFS VFS module
-  when: config.be.variant == 'vfs' and
-        inventory_hostname in groups['cluster']
-  yum:
-    name: samba-vfs-cephfs
-    state: present
+- name: Install ceph related samba packages
+  when: inventory_hostname in groups['cluster']
+  block:
+    - name: Install VFS module
+      when: config.be.variant == 'vfs'
+      yum:
+        name: samba-vfs-cephfs
+        state: present
+
+    - name: Install CTDB RADOS helper
+      when: config.data.ctdb_mutex == 'rados'
+      yum:
+        name: ctdb-ceph-mutex
+        state: present

--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -361,6 +361,7 @@ environments:
 
     data:
       branch: main
+      ctdb_mutex: rados
 
     nodes:
       setup:


### PR DESCRIPTION
It has been a while since a dedicated helper got added to CTDB for managing cluster locks directly on ceph RADOS. Therefore provide a mechanism to optionally configure it instead of the default shared file system locks.

See [man ctdb_mutex_ceph_rados_helper(7)](https://ctdb.samba.org/manpages/ctdb_mutex_ceph_rados_helper.7.html) for more details.