### PR TITLE
samba: Make adjustments to vfs_acl_xattr configuration

### DIFF
--- a/playbooks/ansible/cluster-cephfs.yml
+++ b/playbooks/ansible/cluster-cephfs.yml
@@ -22,6 +22,3 @@ samba_netbios_name: "SIT-CEPHFS-TEST"
 
 samba_shares:
   - name: share
-    samba:
-      options:
-        "acl_xattr:ignore system acls": "yes"

--- a/playbooks/ansible/cluster-cephfs.yml
+++ b/playbooks/ansible/cluster-cephfs.yml
@@ -22,3 +22,6 @@ samba_netbios_name: "SIT-CEPHFS-TEST"
 
 samba_shares:
   - name: share
+    samba:
+      options:
+        "acl_xattr:security_acl_name": "user.NTACL"

--- a/playbooks/ansible/cluster-glusterfs.yml
+++ b/playbooks/ansible/cluster-glusterfs.yml
@@ -69,9 +69,6 @@ samba_netbios_name: "SIT-GLUSTERFS-TEST"
 
 samba_shares:
   - name: vol-replicate
-    samba:
-      options:
-        "acl_xattr:ignore system acls": "yes"
     glusterfs:
       type: "replicate"
       subvolume_size: "{{ config.groups['cluster']|length }}"
@@ -90,9 +87,6 @@ samba_shares:
         performance.parallel-readdir: 'on'
 
   - name: vol-disperse
-    samba:
-      options:
-        "acl_xattr:ignore system acls": "yes"
     glusterfs:
       type: "disperse"
       subvolume_size: 3

--- a/playbooks/ansible/cluster-glusterfs.yml
+++ b/playbooks/ansible/cluster-glusterfs.yml
@@ -69,6 +69,9 @@ samba_netbios_name: "SIT-GLUSTERFS-TEST"
 
 samba_shares:
   - name: vol-replicate
+    samba:
+      options:
+        "acl_xattr:security_acl_name": "user.NTACL"
     glusterfs:
       type: "replicate"
       subvolume_size: "{{ config.groups['cluster']|length }}"
@@ -87,6 +90,9 @@ samba_shares:
         performance.parallel-readdir: 'on'
 
   - name: vol-disperse
+    samba:
+      options:
+        "acl_xattr:security_acl_name": "user.NTACL"
     glusterfs:
       type: "disperse"
       subvolume_size: 3

--- a/playbooks/ansible/cluster-gpfs.yml
+++ b/playbooks/ansible/cluster-gpfs.yml
@@ -22,5 +22,8 @@ samba_netbios_name: "SIT-GPFS-TEST"
 
 samba_shares:
   - name: share
+    samba:
+      options:
+        "acl_xattr:security_acl_name": "user.NTACL"
 
 nsd_device: "/dev/vdb"

--- a/playbooks/ansible/cluster-gpfs.yml
+++ b/playbooks/ansible/cluster-gpfs.yml
@@ -22,8 +22,5 @@ samba_netbios_name: "SIT-GPFS-TEST"
 
 samba_shares:
   - name: share
-    samba:
-      options:
-        "acl_xattr:ignore system acls": "yes"
 
 nsd_device: "/dev/vdb"

--- a/playbooks/ansible/cluster-xfs.yml
+++ b/playbooks/ansible/cluster-xfs.yml
@@ -22,5 +22,8 @@ samba_netbios_name: "SIT-XFS-TEST"
 
 samba_shares:
   - name: share
+    samba:
+      options:
+        "acl_xattr:security_acl_name": "user.NTACL"
     xfs:
       device: "/dev/vdb"

--- a/playbooks/ansible/cluster-xfs.yml
+++ b/playbooks/ansible/cluster-xfs.yml
@@ -22,8 +22,5 @@ samba_netbios_name: "SIT-XFS-TEST"
 
 samba_shares:
   - name: share
-    samba:
-      options:
-        "acl_xattr:ignore system acls": "yes"
     xfs:
       device: "/dev/vdb"

--- a/playbooks/ansible/roles/samba.setup/files/smbd_dac_override.te
+++ b/playbooks/ansible/roles/samba.setup/files/smbd_dac_override.te
@@ -1,0 +1,10 @@
+
+module smbd_dac_override 1.0;
+
+require {
+	type smbd_t;
+	class capability dac_override;
+}
+
+#============= smbd_t ==============
+allow smbd_t self:capability dac_override;

--- a/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
@@ -26,3 +26,35 @@
         search_string: "CTDB_SAMBA_SKIP_SHARE_CHECK"
         line: "CTDB_SAMBA_SKIP_SHARE_CHECK=yes"
         state: present
+
+- name: Temporarily allow cap_dac_override for smbd from SELinux
+  when: config.be.variant == 'default'
+  block:
+    - name: Remove any existing policy package
+      command: semodule -r smbd_dac_override
+      failed_when: false
+
+    - name: Copy required type enforcement file
+      copy:
+        src: smbd_dac_override.te
+        dest: /tmp
+
+    - name: Compile SELinux module file
+      command: checkmodule -M -m -o smbd_dac_override.mod smbd_dac_override.te
+      args:
+        chdir: /tmp
+
+    - name: Build SELinux policy package
+      command: semodule_package -o smbd_dac_override.pp -m smbd_dac_override.mod
+      args:
+        chdir: /tmp
+
+    - name: Load SELinux policy package
+      command: semodule -i smbd_dac_override.pp
+      args:
+        chdir: /tmp
+
+    - name: Remove temporary policy files
+      file:
+        path: /tmp/smbd_dac_override.*
+        state: absent

--- a/playbooks/ansible/roles/samba.setup/tasks/xfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/xfs/main.yml
@@ -1,1 +1,31 @@
 ---
+- name: Temporarily allow cap_dac_override for smbd from SELinux
+  block:
+    - name: Remove any existing policy package
+      command: semodule -r smbd_dac_override
+      failed_when: false
+
+    - name: Copy required type enforcement file
+      copy:
+        src: smbd_dac_override.te
+        dest: /tmp
+
+    - name: Compile SELinux module file
+      command: checkmodule -M -m -o smbd_dac_override.mod smbd_dac_override.te
+      args:
+        chdir: /tmp
+
+    - name: Build SELinux policy package
+      command: semodule_package -o smbd_dac_override.pp -m smbd_dac_override.mod
+      args:
+        chdir: /tmp
+
+    - name: Load SELinux policy package
+      command: semodule -i smbd_dac_override.pp
+      args:
+        chdir: /tmp
+
+    - name: Remove temporary policy files
+      file:
+        path: /tmp/smbd_dac_override.*
+        state: absent


### PR DESCRIPTION
Following changes are made:
- Remove 'ignore system acls' to keep lossy mapping to POSIX ACLs.
- Configure xattr name to store NT ACLs as "user.NTACL".

We introduce a temporary workaround to allow _smbd_ to assume _cap_dac_override_ when operating as _root_ until official fixes are available.