### PR TITLE
devel: fix symlink to inventory file

### DIFF
--- a/devel/inventory
+++ b/devel/inventory
@@ -1,1 +1,1 @@
-../playbooks/site_inventory
+../playbooks/ansible/site_inventory


### PR DESCRIPTION
The inventory file location in the playbooks has changed. Fix the symlink so that we can use the ansible scripts from the devel directory again.

