### PR TITLE
settings.yml: Use default OS for GlusterFS nodes

### DIFF
--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -301,7 +301,6 @@ environments:
         networks:
           private: 200
         groups: [admin]
-        os: centos8
 
       client:
         cpu_weight: 1
@@ -321,7 +320,6 @@ environments:
         ctdb:
           public: 10
         groups: [cluster]
-        os: centos8
         accounts: [default]
 
   xfs:


### PR DESCRIPTION
All required gluster-ansible packages were recently built and available via fedora copr(epel-9). Make use of the repository to finally switch the platform from EOL CentOS Stream 8.