### PR TITLE
Add support for samba setup using ceph `smb` manager module

### DIFF
--- a/playbooks/ansible/cluster-cephfs.yml
+++ b/playbooks/ansible/cluster-cephfs.yml
@@ -1,4 +1,13 @@
 ---
+node_network_public_interfaces: >-
+  {{
+    config.nodes |
+    dict2items |
+    selectattr('value.groups', 'contains', 'cluster') |
+    map(attribute='value.networks.public') |
+    list
+  }}
+
 ctdb_network_private_interfaces: >-
   {{
     config.nodes |

--- a/playbooks/ansible/roles/sit.cephfs/tasks/main.yml
+++ b/playbooks/ansible/roles/sit.cephfs/tasks/main.yml
@@ -90,6 +90,26 @@
       command: /root/cephadm shell -- ceph config generate-minimal-conf
       register: ceph_conf
 
+    - name: Enable and create smb cluster using mgr module
+      when: config.be.variant == 'mgr'
+      block:
+        - name: Enable smb mgr module
+          command: /root/cephadm shell -- ceph mgr module enable smb
+
+        - name: Wait for mgr restart
+          command: /root/cephadm shell -- ceph orch ls mgr --format=json
+          register: mgr_status
+          until: >-
+            mgr_status.stdout | from_json | json_query(
+              "[*] | [status.running == status.size]") | length > 0
+          retries: 100
+          delay: 1
+
+        - name: Create a smb cluster
+          command: /root/cephadm shell -- ceph smb apply -i -
+          args:
+            stdin: "{{ lookup('template', 'ceph.smb.cluster.yml.j2') }}"
+
 - name: Generate a ceph conf with key
   copy:
     dest: "/etc/ceph/sit.ceph.conf"
@@ -97,3 +117,22 @@
       {{ ceph_conf.stdout }}
 
       {{ ceph_auth.stdout }}
+
+- name: Create and configure shares
+  when: config.be.variant == 'mgr'
+  block:
+    - name: Create shares
+      vars:
+        name: "{{ item.name }}"
+        path: "{{ config.paths.mount }}/{{ item.name }}"
+        mode: "0777"
+        volume: "{{ item }}"
+      include_tasks:
+        file: new_volume.yml
+      loop: "{{ samba_shares }}"
+
+    - name: Create samba shares
+      command: /root/cephadm shell -- ceph smb apply -i -
+      args:
+        stdin: "{{ lookup('template', 'ceph.smb.share.yml.j2') }}"
+      run_once: true

--- a/playbooks/ansible/roles/sit.cephfs/templates/ceph.smb.cluster.yml.j2
+++ b/playbooks/ansible/roles/sit.cephfs/templates/ceph.smb.cluster.yml.j2
@@ -1,0 +1,39 @@
+resources:
+- resource_type: ceph.smb.usersgroups
+  users_groups_id: siteacct
+  intent: present
+  values:
+    {%- for account_group in config.accounts +%}
+      {%- if config.accounts[account_group].users +%}
+      users:
+        {%- for user_name in config.accounts[account_group].users +%}
+          {%- set account = config.accounts[account_group].users[user_name] +%}
+          {%- if account.samba +%}
+        - name: {{ user_name }}
+          password: {{ account.password }}
+          {%- endif +%}
+        {%- endfor +%}
+      {%- else +%}
+      users: []
+      {%- endif +%}
+    {%- endfor +%}
+    {%- for account_group in config.accounts +%}
+      {%- if config.accounts[account_group].groups +%}
+      groups:
+        {%- for group_name in config.accounts[account_group].groups +%}
+        - name: {{ group_name }}
+        {%- endfor +%}
+      {%- else +%}
+      groups: []
+      {%- endif +%}
+    {%- endfor +%}
+
+- resource_type: ceph.smb.cluster
+  cluster_id: site
+  intent: present
+  auth_mode: user
+  user_group_settings:
+    - source_type: resource
+      ref: siteacct
+  placement:
+    hosts: [ {{ inventory_hostname }} ]

--- a/playbooks/ansible/roles/sit.cephfs/templates/ceph.smb.share.yml.j2
+++ b/playbooks/ansible/roles/sit.cephfs/templates/ceph.smb.share.yml.j2
@@ -1,0 +1,12 @@
+resources:
+{%- for share in samba_shares +%}
+- resource_type: ceph.smb.share
+  cluster_id: site
+  share_id: {{ share.name }}
+  intent: present
+  name: {{ share.name }}-{{ config.be.name }}-{{ config.be.variant }}
+  cephfs:
+    volume: sit_fs
+    path: /
+    subvolume: {{ share.name }}
+{%- endfor +%}

--- a/playbooks/ansible/roles/test.sit-test-cases/tasks/prepare/main.yml
+++ b/playbooks/ansible/roles/test.sit-test-cases/tasks/prepare/main.yml
@@ -30,7 +30,7 @@
     src: test-info.yml.j2
     dest: /root/test-info.yml
   vars:
-    public_interfaces: "{{ ctdb_network_public_interfaces }}"
+    public_interfaces: "{{ (config.be.variant == 'mgr') | ternary(node_network_public_interfaces, ctdb_network_public_interfaces) }}"
     sharenames: "{{ samba_shares | map(attribute='name') | list }}"
 
 - name: Create a symlink for test-info.yml file

--- a/playbooks/ansible/setup-cluster.yml
+++ b/playbooks/ansible/setup-cluster.yml
@@ -15,4 +15,5 @@
       when: config.samba
     - role: ctdb.setup
       when: config.samba
-    - users.setup
+    - role: users.setup
+      when: config.users

--- a/playbooks/roles/local.defaults/templates/config.yml.j2
+++ b/playbooks/roles/local.defaults/templates/config.yml.j2
@@ -75,6 +75,7 @@ config:
   tests: {{ settings.tests }}
 
   samba: {{ settings.environments[be].samba | default('true') }}
+  users: {{ settings.environments[be].users | default('true') }}
 
   provisioners:
   {%- for prov in settings.environments[be].nodes | dict2items | map(attribute='value.provisioner', default='vagrant') | unique +%}

--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -357,6 +357,7 @@ environments:
     cpus: 2
     memory: 1024
     samba: "{{ variant != 'mgr' }}"
+    users: "{{ variant != 'mgr' }}"
 
     data:
       branch: main

--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -356,6 +356,7 @@ environments:
   cephfs:
     cpus: 2
     memory: 1024
+    samba: "{{ variant != 'mgr' }}"
 
     data:
       branch: main


### PR DESCRIPTION
- Enable and create samba shares with ceph `smb` mgr module.
- Explicit creation of samba users via _users.setup_ is skipped(achieved through `smb` mgr module).
- Client access directed at node running smb service.

Finally, we have a new backend - **cephfs.mgr.vfs** 😀 .