### PR TITLE
smb.conf: Avoid setting duplicate/ignored options

### DIFF
--- a/playbooks/ansible/roles/samba.setup/templates/smb.conf.j2
+++ b/playbooks/ansible/roles/samba.setup/templates/smb.conf.j2
@@ -7,8 +7,6 @@ server string = Samba server version %v
 workgroup = MYGROUP
 security = user
 
-kernel share modes = No
-map archive = No
 posix locking = No
 kernel change notify = no
 


### PR DESCRIPTION
* '[kernel share modes](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#KERNELSHAREMODES)' is disabled by default.
>  This parameter defaults to no. Setting it to yes requires a file system module that supports file system sharemodes, otherwise attempts to access files will fail with a sharing violation.
>
> Default: kernel share modes = no 
* '[store dos attributes](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#STOREDOSATTRIBUTES)', which is set by default, assumes 'map archive' to be disabled.
> When this parameter is set it will override the parameters [map hidden](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#MAPHIDDEN), [map system](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#MAPSYSTEM), [map archive](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#MAPARCHIVE) and [map readonly](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#MAPREADONLY) and they will behave as if they were set to off.
>
> Default: store dos attributes = yes 