### PR TITLE
sit.cephfs: Add share configured with `vfs_ceph_new`(non-mgr)

### DIFF
--- a/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
+++ b/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
@@ -3,7 +3,10 @@
 comment = Volume '{{ volume.name }}' from {{ config.be.name }}({{ config.be.variant }} {{ method }})
 vfs objects = acl_xattr ceph_snapshots
   {%- if method != 'kclient' %}
-    {%- set vfs = 'ceph' %} {{ vfs }}
+    {%- set vfs = 'ceph_new' %}
+    {%- if method == 'vfs' %}
+      {%- set vfs = 'ceph' %}
+    {%- endif %} {{ vfs }}
 {{ vfs }}:config_file = /etc/ceph/sit.ceph.conf
 {{ vfs }}:user_id = sit
 path = {{ subvol }}

--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -362,7 +362,7 @@ environments:
     data:
       branch: main
       ctdb_mutex: rados
-      methods: ['klcient', 'vfs']
+      methods: ['klcient', 'vfs', 'vfs.new']
 
     nodes:
       setup:


### PR DESCRIPTION
depends on #117 