### PR TITLE
Group possible backend share configurations under same environment

### DIFF
--- a/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Prepare CephFS VFS support
-  when: config.be.variant == 'vfs'
   block:
     - name: Process OS specific tasks
       include_tasks: "{{ include_file }}"
@@ -28,7 +27,6 @@
         state: present
 
 - name: Temporarily allow cap_dac_override for smbd from SELinux
-  when: config.be.variant == 'default'
   block:
     - name: Remove any existing policy package
       command: semodule -r smbd_dac_override

--- a/playbooks/ansible/roles/samba.setup/tasks/gpfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/gpfs/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Run smbd unconfined
-  when: config.be.variant == 'vfs'
   block:
     - name: Configure SElinux context for smbd
       sefcontext:

--- a/playbooks/ansible/roles/sit.cephfs/tasks/repo/centos.yml
+++ b/playbooks/ansible/roles/sit.cephfs/tasks/repo/centos.yml
@@ -3,7 +3,6 @@
   when: inventory_hostname in groups['cluster']
   block:
     - name: Install VFS module
-      when: config.be.variant == 'vfs'
       yum:
         name: samba-vfs-cephfs
         state: present

--- a/playbooks/ansible/roles/sit.cephfs/templates/ceph.smb.share.yml.j2
+++ b/playbooks/ansible/roles/sit.cephfs/templates/ceph.smb.share.yml.j2
@@ -1,12 +1,16 @@
 resources:
 {%- for share in samba_shares +%}
+  {%- for method in config.be.methods +%}
+    {%- set provider = 'samba-vfs' +%}
 - resource_type: ceph.smb.share
   cluster_id: site
   share_id: {{ share.name }}
   intent: present
-  name: {{ share.name }}-{{ config.be.name }}-{{ config.be.variant }}
+  name: {{ share.name }}-{{ config.be.name }}-{{ config.be.variant }}-{{ method }}
   cephfs:
     volume: sit_fs
     path: /
     subvolume: {{ share.name }}
+    provider: {{ provider }}
+  {%- endfor +%}
 {%- endfor +%}

--- a/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
+++ b/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
@@ -1,15 +1,18 @@
-[{{ name }}-{{ config.be.name }}-{{ config.be.variant }}]
-comment = Volume '{{ name }}' from {{ config.be.name }}({{ config.be.variant }})
+{%- for method in config.be.methods +%}
+[{{ volume.name }}-{{ config.be.name }}-{{ config.be.variant }}-{{ method }}]
+comment = Volume '{{ volume.name }}' from {{ config.be.name }}({{ config.be.variant }} {{ method }})
 vfs objects = acl_xattr ceph_snapshots
-{%- if config.be.variant == 'vfs' %} ceph
-ceph:config_file = /etc/ceph/sit.ceph.conf
-ceph:user_id = sit
+  {%- if method != 'kclient' %}
+    {%- set vfs = 'ceph' %} {{ vfs }}
+{{ vfs }}:config_file = /etc/ceph/sit.ceph.conf
+{{ vfs }}:user_id = sit
 path = {{ subvol }}
-{%- else +%}
+  {%- else +%}
 path = {{ path }}
-{%- endif +%}
+  {%- endif +%}
 browseable = yes
 read only = no
-{%- for option, value in volume.samba.options.items() | default([]) +%}
+  {%- for option, value in volume.samba.options.items() | default([]) +%}
 {{ option }} = {{ value }}
+  {%- endfor +%}
 {%- endfor +%}

--- a/playbooks/ansible/roles/sit.gpfs/tasks/main.yml
+++ b/playbooks/ansible/roles/sit.gpfs/tasks/main.yml
@@ -124,6 +124,6 @@
         - name: Configure shares
           command: >-
             /usr/lpp/mmfs/bin/mmsmb export add
-              {{ item.name }}-{{ config.be.name }}-{{ config.be.variant }}
-              /gpfs/sit_fs/{{ item.name }}
-          loop: "{{ samba_shares }}"
+              {{ item[0].name }}-{{ config.be.name }}-{{ config.be.variant }}-{{ item[1] }}
+              /gpfs/sit_fs/{{ item[0].name }}
+          loop: "{{ samba_shares | product(config.be.methods) | list }}"

--- a/playbooks/ansible/roles/sit.gpfs/templates/smb_share.conf.j2
+++ b/playbooks/ansible/roles/sit.gpfs/templates/smb_share.conf.j2
@@ -1,8 +1,10 @@
-[{{ name }}-{{ config.be.name }}-{{ config.be.variant }}]
-comment = Volume '{{ name }}' from {{ config.be.name }}({{ config.be.variant }})
-vfs objects = acl_xattr {%- if config.be.variant == 'vfs' %} gpfs{% endif +%}
+{%- for method in config.be.methods +%}
+[{{ volume.name }}-{{ config.be.name }}-{{ config.be.variant }}-{{ method }}]
+comment = Volume '{{ volume.name }}' from {{ config.be.name }}({{ config.be.variant }} {{ method }})
+vfs objects = acl_xattr {%- if method != 'kclient' %} gpfs{% endif +%}
 path = {{ path }}
 read only = no
-{%- for option, value in volume.samba.options.items() | default([]) +%}
+  {%- for option, value in volume.samba.options.items() | default([]) +%}
 {{ option }} = {{ value }}
+  {%- endfor +%}
 {%- endfor +%}

--- a/playbooks/ansible/roles/test.sit-test-cases/tasks/prepare/main.yml
+++ b/playbooks/ansible/roles/test.sit-test-cases/tasks/prepare/main.yml
@@ -31,7 +31,6 @@
     dest: /root/test-info.yml
   vars:
     public_interfaces: "{{ (config.be.variant == 'mgr') | ternary(node_network_public_interfaces, ctdb_network_public_interfaces) }}"
-    sharenames: "{{ samba_shares | map(attribute='name') | list }}"
 
 - name: Create a symlink for test-info.yml file
   file:

--- a/playbooks/ansible/roles/test.sit-test-cases/templates/test-info.yml.j2
+++ b/playbooks/ansible/roles/test.sit-test-cases/templates/test-info.yml.j2
@@ -13,10 +13,20 @@ users:
 backend: {{ config.be.name }}
 
 shares:
-  {%- for share in sharenames +%}
-  {{ share }}-{{ config.be.name }}-{{ config.be.variant }}:
+  {%- for share in samba_shares +%}
+    {%- if config.be.methods is defined +%}
+      {%- for method in config.be.methods +%}
+  {{ share.name }}-{{ config.be.name }}-{{ config.be.variant}}-{{ method }}:
     backend:
       name: {{ config.be.name }}
       variant: {{ config.be.variant}}
-      path: {{ config.paths.mount }}/backends/{{ share }}
+      path: {{ config.paths.mount }}/backends/{{ share.name }}
+      {%- endfor +%}
+    {%- else +%}
+  {{ share.name }}-{{ config.be.name }}-{{ config.be.variant }}:
+    backend:
+      name: {{ config.be.name }}
+      variant: {{ config.be.variant}}
+      path: {{ config.paths.mount }}/backends/{{ share.name }}
+    {%- endif +%}
   {%- endfor +%}

--- a/playbooks/roles/local.defaults/templates/config.yml.j2
+++ b/playbooks/roles/local.defaults/templates/config.yml.j2
@@ -15,6 +15,13 @@ config:
   be:
     name: "{{ be }}"
     variant: "{{ variant }}"
+    {%- if settings.environments[be].data.methods is defined +%}
+      {%- set methods = settings.environments[be].data.methods +%}
+      {%- if variant != 'default' +%}
+        {%- set methods = ['vfs'] +%}
+      {%- endif +%}
+    methods: {{ methods }}
+    {%- endif +%}
 
 {%- if settings.environments[be].domain is defined +%}
   domain: "{{ settings.environments[be].domain }}"

--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -362,6 +362,7 @@ environments:
     data:
       branch: main
       ctdb_mutex: rados
+      methods: ['klcient', 'vfs']
 
     nodes:
       setup:

--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -410,6 +410,7 @@ environments:
       # file inside the zip. It must have a capturing group to extract the
       # version number.
       pattern: "Storage_Scale_Developer-([0-9.]+)-x86_64-Linux-install"
+      methods: ['kclient', 'vfs']
 
     nodes:
       setup:


### PR DESCRIPTION
Key considerations:

- _**cephfs**_ and _**cephfs.vfs**_ are combined together under _**cephfs**_.
  - _**cephfs.mgr.vfs**_ becomes _**cephfs.mgr**_ when shares are configured using ceph smb mgr module.
- A new `methods` field to indicate how variations of each share section are to be configured within _smb.conf_.
  - Special cases:
    - kernel client approach is not yet supported by ceph mgr module. Accordingly we skip this variation.
    - gpfs `scale` variant configuration is always based on _vfs_.  Thus we skip iterating over available methods.

fixes #101 