### PR TITLE
sit.cephfs: Enable clustering for mgr variant

### DIFF
--- a/playbooks/ansible/cluster-cephfs.yml
+++ b/playbooks/ansible/cluster-cephfs.yml
@@ -1,13 +1,4 @@
 ---
-node_network_public_interfaces: >-
-  {{
-    config.nodes |
-    dict2items |
-    selectattr('value.groups', 'contains', 'cluster') |
-    map(attribute='value.networks.public') |
-    list
-  }}
-
 ctdb_network_private_interfaces: >-
   {{
     config.nodes |

--- a/playbooks/ansible/roles/sit.cephfs/templates/ceph.smb.cluster.yml.j2
+++ b/playbooks/ansible/roles/sit.cephfs/templates/ceph.smb.cluster.yml.j2
@@ -36,4 +36,9 @@ resources:
     - source_type: resource
       ref: siteacct
   placement:
-    hosts: [ {{ inventory_hostname }} ]
+    count: {{ config.groups['cluster'] | length }}
+  clustering: always
+  public_addrs:
+    {%- for addr in ctdb_network_public_interfaces +%}
+    - address: {{ addr }}/{{ ctdb_network_public_interface_subnet_mask }}
+    {%- endfor +%}

--- a/playbooks/ansible/roles/test.sit-test-cases/tasks/prepare/main.yml
+++ b/playbooks/ansible/roles/test.sit-test-cases/tasks/prepare/main.yml
@@ -30,7 +30,7 @@
     src: test-info.yml.j2
     dest: /root/test-info.yml
   vars:
-    public_interfaces: "{{ (config.be.variant == 'mgr') | ternary(node_network_public_interfaces, ctdb_network_public_interfaces) }}"
+    public_interfaces: "{{ ctdb_network_public_interfaces }}"
 
 - name: Create a symlink for test-info.yml file
   file:


### PR DESCRIPTION
Clustering support is now natively available with ceph smb mgr module. Make use of `clustering` option to _ceph.smb.cluster_ resource definition along with the placement count and required public addresses.