### PR TITLE
gpfs: Use python 3.9 in CentOS 8

### DIFF
--- a/playbooks/ansible/roles/sit.gpfs/tasks/server/redhat.yml
+++ b/playbooks/ansible/roles/sit.gpfs/tasks/server/redhat.yml
@@ -3,7 +3,7 @@
   dnf:
     name:
       - unzip
-      - python3
+      - python39
       - kernel-devel
       - kernel-headers
       - gcc


### PR DESCRIPTION
The most recent release of GPFS (5.2.1.0) requieres python 3.8+. Since this version doesn't still work with CentOS Stream 9, we install the highest python version available in CentOS 8.

Fixes: #123