### PR TITLE
hosts.update: Remove system installed libldb

### DIFF
--- a/playbooks/roles/hosts.update/tasks/centos9.yml
+++ b/playbooks/roles/hosts.update/tasks/centos9.yml
@@ -1,3 +1,9 @@
 ---
+# https://github.com/samba-in-kubernetes/sit-environment/issues/125
+- name: Remove system installed libldb
+  yum:
+    name: libldb
+    state: absent
+
 - name: Process common OS tasks
   include_tasks: centos.yml


### PR DESCRIPTION
With recent changes to how `libldb` upstream sources are distributed, we are observing conflict for the bundled `libldb` files when there is already a newer version of `libldb` present in the system. Since we do not rely on system installed `libldb` at all, remove it as first step to avoid conflicts.

ref: https://github.com/samba-in-kubernetes/samba-build/pull/66

fixes #125 