### PR TITLE
sit.cephfs: Add proxy enbaled shares with `vfs_ceph_new`(non-mgr)

### DIFF
--- a/playbooks/ansible/roles/ctdb.setup/tasks/main.yml
+++ b/playbooks/ansible/roles/ctdb.setup/tasks/main.yml
@@ -96,6 +96,9 @@
 - name: Enable samba management by ctdb
   command: '{{ config.paths.ctdb.bin }}/ctdb event script enable legacy 50.samba'
 
+- name: Configure libcephfs_proxy socket path for smbd
+  command: systemctl set-environment LIBCEPHFSD_SOCKET=/run/samba/libcephfsd.sock
+
 - name: Restart ctdb
   service: name=ctdb state=restarted enabled=yes
 

--- a/playbooks/ansible/roles/samba.setup/files/smbd_connect_proxy.te
+++ b/playbooks/ansible/roles/samba.setup/files/smbd_connect_proxy.te
@@ -1,0 +1,11 @@
+
+module smbd_connect_proxy 1.0;
+
+require {
+	type smbd_t;
+	type unconfined_t;
+	class unix_stream_socket connectto;
+}
+
+#============= smbd_t ==============
+allow smbd_t unconfined_t:unix_stream_socket connectto;

--- a/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
@@ -34,4 +34,7 @@
 - name: Temporarily allow cap_dac_override for smbd from SELinux
   include_tasks: custom_selinux_policy.yml
   vars:
-    module_name: smbd_dac_override
+    module_name: "{{ item }}"
+  with_items:
+    - smbd_dac_override
+    - smbd_connect_proxy

--- a/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
@@ -26,6 +26,11 @@
         line: "CTDB_SAMBA_SKIP_SHARE_CHECK=yes"
         state: present
 
+    # We create the socket under /run/samba/ to avoid SELinux AVC denial
+    # https://github.com/samba-in-kubernetes/sit-environment/pull/128#issuecomment-2624527331
+    - name: Run libcephfsd for proxy
+      shell: LIBCEPHFSD_SOCKET=/run/samba/libcephfsd.sock nohup /usr/sbin/libcephfsd &> /var/log/ceph/libcephfsd.log &
+
 - name: Temporarily allow cap_dac_override for smbd from SELinux
   block:
     - name: Remove any existing policy package

--- a/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
@@ -32,32 +32,6 @@
       shell: LIBCEPHFSD_SOCKET=/run/samba/libcephfsd.sock nohup /usr/sbin/libcephfsd &> /var/log/ceph/libcephfsd.log &
 
 - name: Temporarily allow cap_dac_override for smbd from SELinux
-  block:
-    - name: Remove any existing policy package
-      command: semodule -r smbd_dac_override
-      failed_when: false
-
-    - name: Copy required type enforcement file
-      copy:
-        src: smbd_dac_override.te
-        dest: /tmp
-
-    - name: Compile SELinux module file
-      command: checkmodule -M -m -o smbd_dac_override.mod smbd_dac_override.te
-      args:
-        chdir: /tmp
-
-    - name: Build SELinux policy package
-      command: semodule_package -o smbd_dac_override.pp -m smbd_dac_override.mod
-      args:
-        chdir: /tmp
-
-    - name: Load SELinux policy package
-      command: semodule -i smbd_dac_override.pp
-      args:
-        chdir: /tmp
-
-    - name: Remove temporary policy files
-      file:
-        path: /tmp/smbd_dac_override.*
-        state: absent
+  include_tasks: custom_selinux_policy.yml
+  vars:
+    module_name: smbd_dac_override

--- a/playbooks/ansible/roles/samba.setup/tasks/custom_selinux_policy.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/custom_selinux_policy.yml
@@ -1,0 +1,29 @@
+---
+- name: Remove any existing policy package
+  command: semodule -r "{{ module_name }}"
+  failed_when: false
+
+- name: Copy required type enforcement file
+  copy:
+    src: "{{ module_name }}.te"
+    dest: /tmp
+
+- name: Compile SELinux module file
+  command: checkmodule -M -m -o "{{ module_name }}.mod" "{{ module_name }}.te"
+  args:
+    chdir: /tmp
+
+- name: Build SELinux policy package
+  command: semodule_package -o "{{ module_name }}.pp" -m "{{ module_name }}.mod"
+  args:
+    chdir: /tmp
+
+- name: Load SELinux policy package
+  command: semodule -i "{{ module_name }}.pp"
+  args:
+    chdir: /tmp
+
+- name: Remove temporary policy files
+  file:
+    path: "/tmp/{{ module_name }}.*"
+    state: absent

--- a/playbooks/ansible/roles/samba.setup/tasks/xfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/xfs/main.yml
@@ -1,31 +1,5 @@
 ---
 - name: Temporarily allow cap_dac_override for smbd from SELinux
-  block:
-    - name: Remove any existing policy package
-      command: semodule -r smbd_dac_override
-      failed_when: false
-
-    - name: Copy required type enforcement file
-      copy:
-        src: smbd_dac_override.te
-        dest: /tmp
-
-    - name: Compile SELinux module file
-      command: checkmodule -M -m -o smbd_dac_override.mod smbd_dac_override.te
-      args:
-        chdir: /tmp
-
-    - name: Build SELinux policy package
-      command: semodule_package -o smbd_dac_override.pp -m smbd_dac_override.mod
-      args:
-        chdir: /tmp
-
-    - name: Load SELinux policy package
-      command: semodule -i smbd_dac_override.pp
-      args:
-        chdir: /tmp
-
-    - name: Remove temporary policy files
-      file:
-        path: /tmp/smbd_dac_override.*
-        state: absent
+  include_tasks: custom_selinux_policy.yml
+  vars:
+    module_name: smbd_dac_override

--- a/playbooks/ansible/roles/sit.cephfs/tasks/git/centos.yml
+++ b/playbooks/ansible/roles/sit.cephfs/tasks/git/centos.yml
@@ -4,3 +4,11 @@
     name:
       - libcephfs-devel
       - librados-devel
+    state: present
+
+- name: Install CephFS proxy components
+  yum:
+    name:
+      - libcephfs-proxy2
+      - libcephfs-daemon
+    state: present

--- a/playbooks/ansible/roles/sit.cephfs/tasks/repo/centos.yml
+++ b/playbooks/ansible/roles/sit.cephfs/tasks/repo/centos.yml
@@ -7,6 +7,13 @@
         name: samba-vfs-cephfs
         state: present
 
+    - name: Install CephFS proxy components
+      yum:
+        name:
+          - libcephfs-proxy2
+          - libcephfs-daemon
+        state: present
+
     - name: Install CTDB RADOS helper
       when: config.data.ctdb_mutex == 'rados'
       yum:

--- a/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
+++ b/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
@@ -9,6 +9,9 @@ vfs objects = acl_xattr ceph_snapshots
     {%- endif %} {{ vfs }}
 {{ vfs }}:config_file = /etc/ceph/sit.ceph.conf
 {{ vfs }}:user_id = sit
+    {%- if method == 'vfs-new-proxy' +%}
+{{ vfs }}:proxy = yes
+    {%- endif +%}
 path = {{ subvol }}
   {%- else +%}
 path = {{ path }}

--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -362,7 +362,7 @@ environments:
     data:
       branch: main
       ctdb_mutex: rados
-      methods: ['kclient', 'vfs', 'vfs-new']
+      methods: ['kclient', 'vfs', 'vfs-new', 'vfs-new-proxy']
 
     nodes:
       setup:


### PR DESCRIPTION
With https://github.com/ceph/ceph/pull/58376 merged we have the libcephfs proxy library and its dependencies available with upstream. Therefore we try to create an additional share with proxy enabled.

Please note that even though we have the required `Recommends:` for dependent packages defined in the [rpm spec file](https://github.com/ceph/ceph/blob/main/ceph.spec.in)(and visible with built rpms) there is an extra mile that DNF takes as part of [libsolv](https://github.com/openSUSE/libsolv) library which prevents it from being presented as installable weak dependencies as one would expect as per the [docs](https://docs.fedoraproject.org/en-US/packaging-guidelines/WeakDependencies/).

depends on https://github.com/ceph/ceph/pull/61537