### PR TITLE
settings.yml: Use CentOS provided vagrant boxes

### DIFF
--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -189,8 +189,8 @@ tests:
 provisioners:
   vagrant:
     images:
-      centos8: generic/centos8s
-      centos9: generic/centos9s
+      centos8: centos/stream8
+      centos9: centos/stream9
 
     networks:
       private: 192.168.122.0/24


### PR DESCRIPTION
We previously [switched](https://github.com/samba-in-kubernetes/sit-environment/commit/d1a8534b10b08c0bca28e3ff4445181f8be5fbba) from official CentOS vagrant boxes as they were not regularly updated. But the situation has improved a lot since the last year where boxes are more frequently updated. On top of all that vagrant cloud platform(HCP-Hashicorp Cloud Platform) has recently implemented [rate limits](https://github.com/hashicorp/vagrant/issues/13590) for downloading boxes. Given all these facts it is better to get back to official CentOS vagrant boxes. These are externally hosted on CentOS cloud(and properly redirected from HCP) allowing us to bypass the throttling seen with HCP.