### PR TITLE
sit.cephfs: Add proxy enbaled shares with `vfs_ceph_new` (mgr)

### DIFF
--- a/playbooks/ansible/roles/sit.cephfs/templates/ceph.smb.share.yml.j2
+++ b/playbooks/ansible/roles/sit.cephfs/templates/ceph.smb.share.yml.j2
@@ -4,6 +4,8 @@ resources:
     {%- set provider = 'samba-vfs/new' +%}
     {%- if method == 'vfs' +%}
       {%- set provider = 'samba-vfs/classic' +%}
+    {%- elif method == 'vfs-proxy' +%}
+      {%- set provider = 'samba-vfs/proxied' +%}
     {%- endif +%}
 - resource_type: ceph.smb.share
   cluster_id: site

--- a/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
+++ b/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
@@ -9,7 +9,7 @@ vfs objects = acl_xattr ceph_snapshots
     {%- endif %} {{ vfs }}
 {{ vfs }}:config_file = /etc/ceph/sit.ceph.conf
 {{ vfs }}:user_id = sit
-    {%- if method == 'vfs-new-proxy' +%}
+    {%- if method == 'vfs-proxy' +%}
 {{ vfs }}:proxy = yes
     {%- endif +%}
 path = {{ subvol }}

--- a/playbooks/roles/local.defaults/templates/config.yml.j2
+++ b/playbooks/roles/local.defaults/templates/config.yml.j2
@@ -21,6 +21,7 @@ config:
         {%- set methods = ['vfs'] +%}
         {%- if variant == 'mgr' %}
           {{ methods.append('vfs-new') }}
+          {{ methods.append('vfs-proxy') }}
         {%- endif +%}
       {%- endif +%}
     methods: {{ methods }}

--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -362,7 +362,7 @@ environments:
     data:
       branch: main
       ctdb_mutex: rados
-      methods: ['kclient', 'vfs', 'vfs-new', 'vfs-new-proxy']
+      methods: ['kclient', 'vfs', 'vfs-new', 'vfs-proxy']
 
     nodes:
       setup:


### PR DESCRIPTION
With https://github.com/ceph/ceph/pull/59740 merged ceph smb manager module is capable of creating shares with `ceph_new:proxy` module option set to "yes". Thus an additional share with proxy support is created for _mgr_ variant.