### PR TITLE
samba.setup: update selinux policy to support negotiation

### DIFF
--- a/playbooks/ansible/roles/samba.setup/files/smbd_connect_proxy.te
+++ b/playbooks/ansible/roles/samba.setup/files/smbd_connect_proxy.te
@@ -4,8 +4,8 @@ module smbd_connect_proxy 1.0;
 require {
 	type smbd_t;
 	type unconfined_t;
-	class unix_stream_socket connectto;
+	class unix_stream_socket { connectto read write };
 }
 
 #============= smbd_t ==============
-allow smbd_t unconfined_t:unix_stream_socket connectto;
+allow smbd_t unconfined_t:unix_stream_socket { connectto read write };


### PR DESCRIPTION
The implementation of the negotiation support requires additional selinux permissions to work correctly.

fixes https://github.com/samba-in-kubernetes/sit-test-cases/issues/98