### PR TITLE
cephfs: Modify libcephfsd buffering mode for `STDOUT` and `STDERR`

### DIFF
--- a/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
@@ -29,7 +29,9 @@
     # We create the socket under /run/samba/ to avoid SELinux AVC denial
     # https://github.com/samba-in-kubernetes/sit-environment/pull/128#issuecomment-2624527331
     - name: Run libcephfsd for proxy
-      shell: LIBCEPHFSD_SOCKET=/run/samba/libcephfsd.sock nohup /usr/sbin/libcephfsd &> /var/log/ceph/libcephfsd.log &
+      shell: >
+        LIBCEPHFSD_SOCKET=/run/samba/libcephfsd.sock nohup stdbuf -oL -eL
+        /usr/sbin/libcephfsd < /dev/null &> /var/log/ceph/libcephfsd.log &
 
 - name: Temporarily allow cap_dac_override for smbd from SELinux
   include_tasks: custom_selinux_policy.yml


### PR DESCRIPTION
Override the default glibc buffering for `STDOUT` and `STDERR` so that the log contents are visible line by line as soon as they are printed by the daemon. In order to avoid the message "nohup: ignoring input" getting printed on to log file we explicitly redirect `STDIN` to _/dev/null_.