### PR TITLE
cephfs: Create and test against case insensitive subvolumes

### DIFF
--- a/playbooks/ansible/cluster-cephfs.yml
+++ b/playbooks/ansible/cluster-cephfs.yml
@@ -25,3 +25,10 @@ samba_shares:
     samba:
       options:
         "acl_xattr:security_acl_name": "user.NTACL"
+  - name: share-cs
+    samba:
+      options:
+        "acl_xattr:security_acl_name": "user.NTACL"
+    cephfs:
+      options:
+        "casesensitive": yes

--- a/playbooks/ansible/roles/sit.cephfs/tasks/new_volume.yml
+++ b/playbooks/ansible/roles/sit.cephfs/tasks/new_volume.yml
@@ -5,6 +5,16 @@
       ceph fs subvolume create sit_fs {{ name }}
         --mode {{ mode | default('0755') }}
   run_once: true
+  when: volume.cephfs.options.casesensitive | default(false)
+
+- name: Create the CephFS subvolume without casesensitivity
+  command: >
+    /root/cephadm shell --
+      ceph fs subvolume create sit_fs {{ name }}
+        --mode {{ mode | default('0755') }}
+          --casesensitive 0
+  run_once: true
+  when: not (volume.cephfs.options.casesensitive | default(false))
 
 - name: Wait until subvolume is ready
   command: /root/cephadm shell -- ceph fs subvolume info sit_fs {{ name }}

--- a/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
+++ b/playbooks/ansible/roles/sit.cephfs/templates/smb_share.conf.j2
@@ -1,24 +1,26 @@
 {%- for method in config.be.methods +%}
+  {%- if method != 'kclient' or (volume.cephfs.options.casesensitive | default(false)) +%}
 [{{ volume.name }}-{{ config.be.name }}-{{ config.be.variant }}-{{ method }}]
 comment = Volume '{{ volume.name }}' from {{ config.be.name }}({{ config.be.variant }} {{ method }})
 vfs objects = acl_xattr ceph_snapshots
-  {%- if method != 'kclient' %}
-    {%- set vfs = 'ceph_new' %}
-    {%- if method == 'vfs' %}
-      {%- set vfs = 'ceph' %}
-    {%- endif %} {{ vfs }}
+    {%- if method != 'kclient' %}
+      {%- set vfs = 'ceph_new' %}
+      {%- if method == 'vfs' %}
+        {%- set vfs = 'ceph' %}
+      {%- endif %} {{ vfs }}
 {{ vfs }}:config_file = /etc/ceph/sit.ceph.conf
 {{ vfs }}:user_id = sit
-    {%- if method == 'vfs-proxy' +%}
+      {%- if method == 'vfs-proxy' +%}
 {{ vfs }}:proxy = yes
-    {%- endif +%}
+      {%- endif +%}
 path = {{ subvol }}
-  {%- else +%}
+    {%- else +%}
 path = {{ path }}
-  {%- endif +%}
+    {%- endif +%}
 browseable = yes
 read only = no
-  {%- for option, value in volume.samba.options.items() | default([]) +%}
+    {%- for option, value in volume.samba.options.items() | default([]) +%}
 {{ option }} = {{ value }}
-  {%- endfor +%}
+    {%- endfor +%}
+  {%- endif +%}
 {%- endfor +%}

--- a/playbooks/ansible/roles/test.sit-test-cases/templates/test-info.yml.j2
+++ b/playbooks/ansible/roles/test.sit-test-cases/templates/test-info.yml.j2
@@ -15,13 +15,17 @@ backend: {{ config.be.name }}
 shares:
   {%- for share in samba_shares +%}
     {%- if config.be.methods is defined +%}
-      {%- for method in config.be.methods +%}
+      {%- if test_casesensitive_cephfs is defined or not (share.cephfs.options.casesensitive | default(false)) +%}
+        {%- for method in config.be.methods +%}
+          {%- if method != 'kclient' or (share.cephfs.options.casesensitive | default(false)) +%}
   {{ share.name }}-{{ config.be.name }}-{{ config.be.variant}}-{{ method }}:
     backend:
       name: {{ config.be.name }}
       variant: {{ config.be.variant}}
       path: {{ config.paths.mount }}/backends/{{ share.name }}
-      {%- endfor +%}
+          {%- endif +%}
+        {%- endfor +%}
+      {%- endif +%}
     {%- else +%}
   {{ share.name }}-{{ config.be.name }}-{{ config.be.variant }}:
     backend:


### PR DESCRIPTION
https://github.com/ceph/ceph/pull/62105 (and subsequently https://github.com/ceph/ceph/pull/62904) is now merged which introduces `--casesensitive` to optionally make a subvolume case **in**sensitive to suite SMB use cases.

Please note that with this change we create shares with and without case sensitive subvolumes but only expose case **in**sensitive based shares for sit-test-cases. Obviously we avoid creating a share with ceph kernel client mount as it is [unsupported](https://docs.ceph.com/en/latest/cephfs/charmap/#restricting-incompatible-client-access) on top of case **in**sensitive subvolumes. One can set `test_casesensitive_cephfs` variable to expose all shares for test runs. For example,

```
EXTRA_VARS="backend=cephfs.mgr test_casesensitive_cephfs=1 test_sanity_only=1" make test
```