### PR TITLE
cephfs: Remove stdbuf usage on libcephfsd

### DIFF
--- a/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
+++ b/playbooks/ansible/roles/samba.setup/tasks/cephfs/main.yml
@@ -30,7 +30,7 @@
     # https://github.com/samba-in-kubernetes/sit-environment/pull/128#issuecomment-2624527331
     - name: Run libcephfsd for proxy
       shell: >
-        LIBCEPHFSD_SOCKET=/run/samba/libcephfsd.sock nohup stdbuf -oL -eL
+        LIBCEPHFSD_SOCKET=/run/samba/libcephfsd.sock nohup
         /usr/sbin/libcephfsd < /dev/null &> /var/log/ceph/libcephfsd.log &
 
 - name: Temporarily allow cap_dac_override for smbd from SELinux


### PR DESCRIPTION
In order to avoid the libc buffering on logs printed by _libcephfsd_ we previously used _stdbuf_ utility to alter the mode. Recently the proxy daemon acquired the logic to write logs directly to `STDOUT` with the help of io vectors (see https://github.com/ceph/ceph/pull/62577). Thus we no longer need _stdbuf_.