### PR TITLE
test-info: Include share information from individual files

### DIFF
--- a/playbooks/ansible/roles/test.sit-test-cases/templates/cephfs-shares-info.yml.j2
+++ b/playbooks/ansible/roles/test.sit-test-cases/templates/cephfs-shares-info.yml.j2
@@ -1,0 +1,14 @@
+shares:
+  {%- for share in samba_shares +%}
+    {%- if test_casesensitive_cephfs is defined or not (share.cephfs.options.casesensitive | default(false)) +%}
+      {%- for method in config.be.methods +%}
+        {%- if method != 'kclient' or (share.cephfs.options.casesensitive | default(false)) +%}
+  {{ share.name }}-{{ config.be.name }}-{{ config.be.variant}}-{{ method }}:
+    backend:
+      name: {{ config.be.name }}
+      variant: {{ config.be.variant}}
+      path: {{ config.paths.mount }}/backends/{{ share.name }}
+        {%- endif +%}
+      {%- endfor +%}
+    {%- endif +%}
+  {%- endfor +%}

--- a/playbooks/ansible/roles/test.sit-test-cases/templates/glusterfs-shares-info.yml.j2
+++ b/playbooks/ansible/roles/test.sit-test-cases/templates/glusterfs-shares-info.yml.j2
@@ -1,0 +1,8 @@
+shares:
+  {%- for share in samba_shares +%}
+  {{ share.name }}-{{ config.be.name }}-{{ config.be.variant }}:
+    backend:
+      name: {{ config.be.name }}
+      variant: {{ config.be.variant}}
+      path: {{ config.paths.mount }}/backends/{{ share.name }}
+  {%- endfor +%}

--- a/playbooks/ansible/roles/test.sit-test-cases/templates/gpfs-shares-info.yml.j2
+++ b/playbooks/ansible/roles/test.sit-test-cases/templates/gpfs-shares-info.yml.j2
@@ -1,0 +1,10 @@
+shares:
+  {%- for share in samba_shares +%}
+    {%- for method in config.be.methods +%}
+  {{ share.name }}-{{ config.be.name }}-{{ config.be.variant}}-{{ method }}:
+    backend:
+      name: {{ config.be.name }}
+      variant: {{ config.be.variant}}
+      path: {{ config.paths.mount }}/backends/{{ share.name }}
+    {%- endfor +%}
+  {%- endfor +%}

--- a/playbooks/ansible/roles/test.sit-test-cases/templates/test-info.yml.j2
+++ b/playbooks/ansible/roles/test.sit-test-cases/templates/test-info.yml.j2
@@ -12,25 +12,4 @@ users:
 
 backend: {{ config.be.name }}
 
-shares:
-  {%- for share in samba_shares +%}
-    {%- if config.be.methods is defined +%}
-      {%- if test_casesensitive_cephfs is defined or not (share.cephfs.options.casesensitive | default(false)) +%}
-        {%- for method in config.be.methods +%}
-          {%- if method != 'kclient' or (share.cephfs.options.casesensitive | default(false)) +%}
-  {{ share.name }}-{{ config.be.name }}-{{ config.be.variant}}-{{ method }}:
-    backend:
-      name: {{ config.be.name }}
-      variant: {{ config.be.variant}}
-      path: {{ config.paths.mount }}/backends/{{ share.name }}
-          {%- endif +%}
-        {%- endfor +%}
-      {%- endif +%}
-    {%- else +%}
-  {{ share.name }}-{{ config.be.name }}-{{ config.be.variant }}:
-    backend:
-      name: {{ config.be.name }}
-      variant: {{ config.be.variant}}
-      path: {{ config.paths.mount }}/backends/{{ share.name }}
-    {%- endif +%}
-  {%- endfor +%}
+{% include config.be.name + '-shares-info.yml.j2' %}

--- a/playbooks/ansible/roles/test.sit-test-cases/templates/xfs-shares-info.yml.j2
+++ b/playbooks/ansible/roles/test.sit-test-cases/templates/xfs-shares-info.yml.j2
@@ -1,0 +1,8 @@
+shares:
+  {%- for share in samba_shares +%}
+  {{ share.name }}-{{ config.be.name }}-{{ config.be.variant }}:
+    backend:
+      name: {{ config.be.name }}
+      variant: {{ config.be.variant}}
+      path: {{ config.paths.mount }}/backends/{{ share.name }}
+  {%- endfor +%}


### PR DESCRIPTION
With increasing number of variations to how shares for different backends are populated, the template for _test-info.yml_ has become convoluted. Moreover it lost its generic nature due to additional checks on various backend specific options while forming the shares section. Thus we split the shares section in to separate backend specific templates and include it in the main _test-info.yml_.