### PR TITLE
sit.cephfs: Disable posix locking for durable handles

### DIFF
--- a/playbooks/ansible/roles/sit.cephfs/templates/ceph.smb.cluster.yml.j2
+++ b/playbooks/ansible/roles/sit.cephfs/templates/ceph.smb.cluster.yml.j2
@@ -42,3 +42,6 @@ resources:
     {%- for addr in ctdb_network_public_interfaces +%}
     - address: {{ addr }}/{{ ctdb_network_public_interface_subnet_mask }}
     {%- endfor +%}
+  custom_smb_global_options:
+    "_allow_customization": "i-take-responsibility-for-all-samba-configuration-errors"
+    "posix locking": "no"


### PR DESCRIPTION
Durable handles are only enabled with `kernel oplocks`, `kernel share modes` and `posix locking` disabled. But with mgr variant `posix locking` was not explicitly disabled and thus few tests failed.

```
# smbtorture \\\\192.168.122.101\\demoshare -U user%passwd --target=samba3 smb2.durable-open.lock-lease
smbtorture 4.24.0pre1-GIT-33762753f03
Using seed 1759143394
time: 2025-09-29 10:56:34.770112
test: lock-lease
time: 2025-09-29 10:56:34.770708
time: 2025-09-29 10:56:39.831182
failure: lock-lease [
../../source4/torture/smb2/durable_open.c:2451: status was NT_STATUS_OBJECT_NAME_NOT_FOUND, expected NT_STATUS_OK: ../../source4/torture/smb2/durable_open.c:2451
]

# smbtorture \\\\192.168.122.101\\demoshare -U user%passwd --target=samba3 smb2.durable-open.lock-oplock
smbtorture 4.24.0pre1-GIT-33762753f03
Using seed 1759143435
time: 2025-09-29 10:57:15.976920
test: lock-oplock
time: 2025-09-29 10:57:15.977286
time: 2025-09-29 10:57:23.846668
failure: lock-oplock [
../../source4/torture/smb2/durable_open.c:2352: status was NT_STATUS_OBJECT_NAME_NOT_FOUND, expected NT_STATUS_OK: ../../source4/torture/smb2/durable_open.c:2352
]
```


smbd logs:

> Sep 29 16:26:39 dev-vm-2 ceph-441d6a82-7423-11f0-9199-52540002ea9e-smb-demosmb-1-0-dev-vm-2-ygayax[103937]: vfs_default_durable_reconnect_fn: vfs_default_durable_cookie - NT_STATUS_NOT_SUPPORTED
> Sep 29 16:26:39 dev-vm-2 ceph-441d6a82-7423-11f0-9199-52540002ea9e-smb-demosmb-1-0-dev-vm-2-ygayax[103937]: vfs_default_durable_reconnect: default_durable_reconnect_fn [durable_open_lease_lock_tlgt3-dF.dat] failed: NT_STATUS_NOT_SUPPORTED