### PR TITLE
backend/cephfs: Workaround SSL failures for shaman API

### DIFF
--- a/ansible/roles/backend/tasks/cephfs/common/centos.yml
+++ b/ansible/roles/backend/tasks/cephfs/common/centos.yml
@@ -1,21 +1,16 @@
 ---
 - name: Identify latest ceph:{{ config.data.branch }} build
-  uri:
-    url: "https://shaman.ceph.com/api/search?\
-            project=ceph&\
-            ref={{ config.data.branch }}&\
-            flavor=default&\
-            status=ready&\
-            distros=centos/{{ config.os[site.os].version }}/x86_64&\
-            sha1=latest"
-    return_content: true
-  register: ceph_shaman
+  shell: curl -s "https://shaman.ceph.com/api/search/?project=ceph&ref={{ config.data.branch }}&flavor=default&status=ready&distros=centos/{{ config.os[site.os].version }}/x86_64&sha1=latest"
+  register: get_ceph_shaman
+
+- set_fact:
+    ceph_shaman: "{{ get_ceph_shaman.stdout | from_json }}"
 
 - name: Create ceph repo
   yum_repository:
-    name: "ceph-{{ config.data.branch }}-{{ ceph_shaman.json[0].sha1 }}"
-    baseurl: "{{ ceph_shaman.json[0].url }}/x86_64"
-    description: "Ceph {{ config.data.branch }} ({{ ceph_shaman.json[0].sha1 }})"
+    name: "ceph-{{ config.data.branch }}-{{ ceph_shaman[0].sha1 }}"
+    baseurl: "{{ ceph_shaman[0].url }}/x86_64"
+    description: "Ceph {{ config.data.branch }} ({{ ceph_shaman[0].sha1 }})"
     enabled: true
     gpgcheck: false
     state: present

--- a/ansible/roles/backend/tasks/cephfs/server/centos.yml
+++ b/ansible/roles/backend/tasks/cephfs/server/centos.yml
@@ -11,7 +11,6 @@
     state: present
 
 - name: Download cephadm
-  get_url:
-    url: "{{ ceph_shaman.json[0].url }}/noarch/cephadm"
-    dest: /root/cephadm
-    mode: 0755
+  shell: >
+    curl -sL "{{ ceph_shaman[0].url }}/noarch/cephadm" -o /root/cephadm &&
+    chmod 0755 /root/cephadm


### PR DESCRIPTION
The _ansible.builtin.uri_ and _ansible.builtin.get_url_ modules fail against shaman.ceph.com with an SSL error (ASN1: NOT_ENOUGH_DATA, status -1), likely due to the endpoint requiring a higher TLS version than the modules negotiate. Replace _uri_ and _get_url_ with shell/curl tasks as a workaround.