### PR TITLE
samba.setup: Restore smbd_dac_override custom SELinux policy

### DIFF
--- a/ansible/roles/samba.setup/files/smbd_dac_override.te
+++ b/ansible/roles/samba.setup/files/smbd_dac_override.te
@@ -1,0 +1,10 @@
+
+module smbd_dac_override 1.0;
+
+require {
+	type smbd_t;
+	class capability dac_override;
+}
+
+#============= smbd_t ==============
+allow smbd_t self:capability dac_override;

--- a/ansible/roles/samba.setup/tasks/cephfs/main.yml
+++ b/ansible/roles/samba.setup/tasks/cephfs/main.yml
@@ -38,5 +38,6 @@
   vars:
     module_name: "{{ item }}"
   with_items:
+    - smbd_dac_override
     - ctdbd_smbd_pid
     - smbd_connect_proxy

--- a/ansible/roles/samba.setup/tasks/xfs/main.yml
+++ b/ansible/roles/samba.setup/tasks/xfs/main.yml
@@ -1,5 +1,8 @@
 ---
-- name: Temporarily allow access on smbd_var_run_t for ctdbd from SELinux
+- name: Temporarily allow access for smbd and/or ctdbd from SELinux
   include_tasks: custom_selinux_policy.yml
   vars:
-    module_name: ctdbd_smbd_pid
+    module_name: "{{ item }}"
+  with_items:
+    - smbd_dac_override
+    - ctdbd_smbd_pid


### PR DESCRIPTION
The `smbd_dac_override` policy was removed in commit b839614 assuming it was included in official packages across all supported distributions. However, only CentOS Stream 10 ships this policy by default. Restore it so that other distributions continue to get _cap_dac_override_ allowed for _smbd_t_.